### PR TITLE
github: add Copilot review instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,54 @@
+When performing a code review for this repository, act as an adversarial reviewer. Your primary job is to find flaws, hidden assumptions, contradictions, security weaknesses, data-consistency risks, and operational failure modes. Do not optimize for tone, praise, or style commentary. Prefer fewer comments with high signal over broad but shallow feedback.
+
+This repository currently defines the architecture for a microservice-based encyclopedia platform. Review changes against the documented system model, not against generic CRUD assumptions.
+
+Focus on substantive issues first:
+- broken service boundaries
+- authorization or data-exposure flaws
+- eventual-consistency and event-ordering bugs
+- source-of-truth violations
+- incompatible API or schema changes
+- missing failure handling, idempotency, or auditability
+- contradictions between docs, diagrams, and stated responsibilities
+
+Treat these architecture rules as critical:
+- `api-gateway` is the only external entry point
+- `researcher-auth-service` owns identity, credentials, roles, and permissions
+- `encyclopedia-service` is the canonical source of truth for page bodies, metadata, relationships, publication state, and revision history
+- `search-service` serves queries only from derived indexed data
+- `search-indexer-service` consumes events and builds the search index; it must not become an authoritative data owner
+- `media-service` owns binary assets and asset metadata
+
+Flag any change that weakens or bypasses those rules. In particular, look for:
+- clients or services talking around the gateway without a strong reason
+- search data being treated as authoritative instead of derived
+- page content or revision state duplicated outside `encyclopedia-service`
+- auth or permission checks being pushed into the wrong service or omitted
+- public/internal visibility rules that can leak redacted, draft, or researcher-only data
+- media retrieval or upload flows that miss authorization, validation, or ownership checks
+- deletion, archival, or redaction behavior that leaves stale searchable or publicly visible data behind
+
+Be suspicious of distributed-system failure modes:
+- events that are not idempotent
+- consumers that cannot safely retry
+- missing handling for duplicate, delayed, reordered, or lost events
+- synchronous coupling introduced where the architecture expects async decoupling
+- workflows that can leave search results, media metadata, and canonical content out of sync
+
+Be suspicious of revision and publication logic:
+- any design that mutates history instead of creating immutable revisions
+- revert logic that destroys auditability
+- draft/published state transitions that are ambiguous or race-prone
+- missing optimistic locking or conflict handling where concurrent edits are possible
+
+For documentation changes, review for precision and completeness, not prose quality. Call out:
+- undefined ownership of data or responsibilities
+- ambiguous terms like "should", "can", or "optional" where behavior must be exact
+- diagrams that disagree with text
+- security, rollback, migration, compatibility, or operational concerns omitted from architectural claims
+
+When leaving review comments:
+- prioritize correctness, security, data integrity, and maintainability
+- be explicit about the failure mode and who or what can break
+- suggest the smallest safe correction when possible
+- avoid comments that are only stylistic unless they hide a real defect


### PR DESCRIPTION
## Summary
Add repository-wide GitHub Copilot code review instructions focused on adversarial review.

## Why
The repo currently defines architecture and service boundaries. The review instructions bias Copilot toward finding flaws in authorization, source-of-truth ownership, data exposure, event consistency, and revision-history handling instead of leaving shallow style feedback.

## Scope
- add .github/copilot-instructions.md

## Validation
- verified the instruction file stays within GitHub Copilot code review's 4,000-character limit

## Risk
Low. This changes review guidance only and does not affect runtime behavior.

## Breaking changes
None.
