### PR TITLE
ci: add Python test workflows

### DIFF
--- a/.github/workflows/researcher-auth-tests.yml
+++ b/.github/workflows/researcher-auth-tests.yml
@@ -1,0 +1,34 @@
+name: Researcher Auth Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  researcher-auth-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12"]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: services/researcher-auth-service/requirements.txt
+
+      - name: Install auth service dependencies
+        working-directory: services/researcher-auth-service
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
+
+      - name: Run auth service tests
+        working-directory: services/researcher-auth-service
+        run: pytest

--- a/.github/workflows/shared-tests.yml
+++ b/.github/workflows/shared-tests.yml
@@ -1,0 +1,34 @@
+name: Shared Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  shared-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12"]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: shared/pyproject.toml
+
+      - name: Install shared test dependencies
+        working-directory: shared
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install "pydantic>=2.0.0" "pytest>=7.0.0"
+
+      - name: Run shared tests
+        working-directory: shared
+        run: pytest


### PR DESCRIPTION
## Summary
Add GitHub Actions workflows that run the existing unit tests on every push and pull request.

## Scope
- add a workflow for shared tests
- add a workflow for researcher-auth-service tests
- run both workflows on Python 3.11 and 3.12

## Why
The repository now contains runnable Python test suites, but there is no CI coverage to catch regressions automatically.

## Validation
- parsed both workflow files locally as YAML
- verified the workflows target the existing test directories and dependency files

## Risk
Low. This changes CI configuration only.

## Breaking changes
None.
