### PR TITLE
chore: combine auth service dependency updates

### DIFF
--- a/services/researcher-auth-service/requirements.txt
+++ b/services/researcher-auth-service/requirements.txt
@@ -1,11 +1,11 @@
 fastapi==0.111.0
-fastapi-users[sqlalchemy]==13.0.0
+fastapi-users[sqlalchemy]==15.0.2
 asyncpg==0.29.0
 cryptography==46.0.7
-pyjwt==2.8.0
+pyjwt>=2.10.1
 pydantic[email]==2.7.4
 pydantic-settings==2.3.4
-pytest==8.2.2
 httpx==0.27.0
-pytest-asyncio==0.23.7
+pytest==9.0.3
+pytest-asyncio==1.3.0
 aiosqlite==0.20.0


### PR DESCRIPTION
## Summary

Combines the open Dependabot dependency updates for `services/researcher-auth-service` into one PR.

This supersedes:

- #4
- #5
- #6

## Dependency changes

- `fastapi-users[sqlalchemy]`: `13.0.0` -> `15.0.2`
- `pyjwt`: `2.8.0` -> `>=2.10.1`
- `pytest`: `8.2.2` -> `9.0.3`
- `pytest-asyncio`: `0.23.7` -> `1.3.0`
