### PR TITLE
encyclopedia: implement service scaffold, history, lifecycle, and metadata

### DIFF
--- a/.github/workflows/encyclopedia-tests.yml
+++ b/.github/workflows/encyclopedia-tests.yml
@@ -1,0 +1,34 @@
+name: Encyclopedia Service Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  encyclopedia-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12"]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: services/encyclopedia/requirements.txt
+
+      - name: Install encyclopedia-service dependencies
+        working-directory: services/encyclopedia
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
+
+      - name: Run encyclopedia-service tests
+        working-directory: services/encyclopedia
+        run: python -m pytest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -98,12 +98,26 @@ services:
     environment:
       DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER:-admin}:${POSTGRES_PASSWORD:-admin}@db:5432/auth_db
 
+  encyclopedia-service:
+    build:
+      context: .
+      dockerfile: services/encyclopedia/Dockerfile
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      ENCYCLOPEDIA_SERVICE_DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER:-admin}:${POSTGRES_PASSWORD:-admin}@db:5432/encyclopedia_db
+    ports:
+      - "8001:8000"
+
   api-gateway:
     build:
       context: .
       dockerfile: services/api-gateway/Dockerfile
     depends_on:
       researcher-auth-service:
+        condition: service_started
+      encyclopedia-service:
         condition: service_started
     environment:
       API_GATEWAY_RESEARCHER_AUTH_BASE_URL: http://researcher-auth-service:8000

--- a/init-db.sql
+++ b/init-db.sql
@@ -1,1 +1,2 @@
 CREATE DATABASE auth_db;
+CREATE DATABASE encyclopedia_db;

--- a/services/encyclopedia/Dockerfile
+++ b/services/encyclopedia/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.11-slim-bullseye
+
+WORKDIR /app
+
+COPY services/encyclopedia/requirements.txt ./requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY services/encyclopedia/ ./
+
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/services/encyclopedia/config.py
+++ b/services/encyclopedia/config.py
@@ -1,0 +1,19 @@
+from functools import lru_cache
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    encyclopedia_service_host: str = "0.0.0.0"
+    encyclopedia_service_port: int = 8000
+    database_url: str = "postgresql+asyncpg://admin:admin@db:5432/encyclopedia_db"
+
+    model_config = SettingsConfigDict(
+        env_prefix="ENCYCLOPEDIA_SERVICE_",
+        case_sensitive=False,
+    )
+
+
+@lru_cache
+def get_settings() -> Settings:
+    return Settings()

--- a/services/encyclopedia/db.py
+++ b/services/encyclopedia/db.py
@@ -1,0 +1,46 @@
+from functools import lru_cache
+from typing import AsyncGenerator
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession, async_sessionmaker, create_async_engine
+
+from config import get_settings
+
+
+@lru_cache
+def get_engine() -> AsyncEngine:
+    settings = get_settings()
+    engine_kwargs: dict[str, object] = {}
+    if settings.database_url.startswith("sqlite"):
+        from sqlalchemy.pool import StaticPool
+
+        engine_kwargs = {
+            "poolclass": StaticPool,
+            "connect_args": {"check_same_thread": False},
+        }
+
+    return create_async_engine(settings.database_url, **engine_kwargs)
+
+
+@lru_cache
+def get_session_maker() -> async_sessionmaker[AsyncSession]:
+    return async_sessionmaker(get_engine(), expire_on_commit=False)
+
+
+async def get_async_session() -> AsyncGenerator[AsyncSession, None]:
+    async with get_session_maker() as session:
+        yield session
+
+
+async def check_database_connection() -> None:
+    async with get_engine().connect() as connection:
+        await connection.execute(text("SELECT 1"))
+
+
+async def dispose_engine() -> None:
+    await get_engine().dispose()
+
+
+def reset_database_state() -> None:
+    get_session_maker.cache_clear()
+    get_engine.cache_clear()

--- a/services/encyclopedia/db.py
+++ b/services/encyclopedia/db.py
@@ -28,7 +28,7 @@ def get_session_maker() -> async_sessionmaker[AsyncSession]:
 
 
 async def get_async_session() -> AsyncGenerator[AsyncSession, None]:
-    async with get_session_maker() as session:
+    async with get_session_maker()() as session:
         yield session
 
 

--- a/services/encyclopedia/domain.py
+++ b/services/encyclopedia/domain.py
@@ -1,0 +1,24 @@
+from enum import Enum
+
+
+class PageType(str, Enum):
+    ARTICLE = "Article"
+    ANOMALY = "Anomaly"
+    ARTIFACT = "Artifact"
+    LOCATION = "Location"
+    INCIDENT = "Incident"
+    EXPEDITION = "Expedition"
+    RESEARCHER_NOTE = "Researcher Note"
+
+
+class PageStatus(str, Enum):
+    DRAFT = "Draft"
+    REVIEW = "Review"
+    PUBLISHED = "Published"
+    ARCHIVED = "Archived"
+    REDACTED = "Redacted"
+
+
+class Visibility(str, Enum):
+    PUBLIC = "Public"
+    INTERNAL = "Internal"

--- a/services/encyclopedia/main.py
+++ b/services/encyclopedia/main.py
@@ -5,6 +5,7 @@ from fastapi import FastAPI
 from db import dispose_engine, get_engine
 from models import Base
 from routes.health import router as health_router
+from routes.pages import router as pages_router
 
 
 @asynccontextmanager
@@ -23,6 +24,7 @@ def create_app() -> FastAPI:
         lifespan=lifespan,
     )
     app.include_router(health_router)
+    app.include_router(pages_router)
     return app
 
 

--- a/services/encyclopedia/main.py
+++ b/services/encyclopedia/main.py
@@ -3,12 +3,14 @@ from contextlib import asynccontextmanager
 from fastapi import FastAPI
 
 from db import dispose_engine, get_engine
+from models import Base
 from routes.health import router as health_router
 
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    get_engine()
+    async with get_engine().begin() as connection:
+        await connection.run_sync(Base.metadata.create_all)
     yield
     await dispose_engine()
 

--- a/services/encyclopedia/main.py
+++ b/services/encyclopedia/main.py
@@ -1,1 +1,27 @@
-print("This is the encyclopedia service.")
+from contextlib import asynccontextmanager
+
+from fastapi import FastAPI
+
+from db import dispose_engine, get_engine
+from routes.health import router as health_router
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    get_engine()
+    yield
+    await dispose_engine()
+
+
+def create_app() -> FastAPI:
+    app = FastAPI(
+        title="Encyclopedia Service",
+        description="Canonical source of truth for encyclopedia pages and revision history.",
+        version="0.1.0",
+        lifespan=lifespan,
+    )
+    app.include_router(health_router)
+    return app
+
+
+app = create_app()

--- a/services/encyclopedia/models.py
+++ b/services/encyclopedia/models.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 from uuid import UUID, uuid4
 
-from sqlalchemy import DateTime, Enum, ForeignKey, Integer, String, Text, UniqueConstraint, Uuid, func
+from sqlalchemy import JSON, DateTime, Enum, ForeignKey, Integer, String, Text, UniqueConstraint, Uuid, func
 from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
 
 from domain import PageStatus, PageType, Visibility
@@ -42,13 +42,17 @@ class PageRecord(Base):
         server_default="1",
         nullable=False,
     )
+    tags: Mapped[list[str]] = mapped_column(JSON, default=list, nullable=False)
+    classifications: Mapped[list[str]] = mapped_column(JSON, default=list, nullable=False)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
         server_default=func.now(),
         nullable=False,
     )
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
         server_default=func.now(),
         onupdate=func.now(),
         nullable=False,
@@ -68,6 +72,24 @@ class PageRecord(Base):
         foreign_keys=[current_published_revision_id],
         post_update=True,
     )
+    related_pages: Mapped[list[PageRelationshipRecord]] = relationship(
+        back_populates="page",
+        cascade="all, delete-orphan",
+        foreign_keys="PageRelationshipRecord.page_id",
+    )
+    media_references: Mapped[list[PageMediaReferenceRecord]] = relationship(
+        back_populates="page",
+        cascade="all, delete-orphan",
+        foreign_keys="PageMediaReferenceRecord.page_id",
+    )
+
+    @property
+    def related_page_ids(self) -> list[UUID]:
+        return [relationship.target_page_id for relationship in self.related_pages]
+
+    @property
+    def media_asset_ids(self) -> list[UUID]:
+        return [reference.asset_id for reference in self.media_references]
 
 
 class RevisionRecord(Base):
@@ -89,6 +111,7 @@ class RevisionRecord(Base):
     content: Mapped[str] = mapped_column(Text, nullable=False)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
+        default=lambda: datetime.now(timezone.utc),
         server_default=func.now(),
         nullable=False,
     )
@@ -100,4 +123,36 @@ class RevisionRecord(Base):
     parent_revision: Mapped[RevisionRecord | None] = relationship(
         remote_side=[id],
         foreign_keys=[parent_revision_id],
+    )
+
+
+class PageRelationshipRecord(Base):
+    __tablename__ = "page_relationships"
+    __table_args__ = (
+        UniqueConstraint("page_id", "target_page_id", name="uq_page_relationship"),
+    )
+
+    id: Mapped[UUID] = mapped_column(Uuid, primary_key=True, default=uuid4)
+    page_id: Mapped[UUID] = mapped_column(Uuid, ForeignKey("pages.id"), nullable=False, index=True)
+    target_page_id: Mapped[UUID] = mapped_column(Uuid, ForeignKey("pages.id"), nullable=False, index=True)
+
+    page: Mapped[PageRecord] = relationship(
+        back_populates="related_pages",
+        foreign_keys=[page_id],
+    )
+
+
+class PageMediaReferenceRecord(Base):
+    __tablename__ = "page_media_references"
+    __table_args__ = (
+        UniqueConstraint("page_id", "asset_id", name="uq_page_media_reference"),
+    )
+
+    id: Mapped[UUID] = mapped_column(Uuid, primary_key=True, default=uuid4)
+    page_id: Mapped[UUID] = mapped_column(Uuid, ForeignKey("pages.id"), nullable=False, index=True)
+    asset_id: Mapped[UUID] = mapped_column(Uuid, nullable=False, index=True)
+
+    page: Mapped[PageRecord] = relationship(
+        back_populates="media_references",
+        foreign_keys=[page_id],
     )

--- a/services/encyclopedia/models.py
+++ b/services/encyclopedia/models.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from datetime import datetime
+from uuid import UUID, uuid4
+
+from sqlalchemy import DateTime, Enum, ForeignKey, Integer, String, Text, UniqueConstraint, Uuid, func
+from sqlalchemy.orm import DeclarativeBase, Mapped, mapped_column, relationship
+
+from domain import PageStatus, PageType, Visibility
+
+
+class Base(DeclarativeBase):
+    pass
+
+
+class PageRecord(Base):
+    __tablename__ = "pages"
+
+    id: Mapped[UUID] = mapped_column(Uuid, primary_key=True, default=uuid4)
+    slug: Mapped[str] = mapped_column(String(255), unique=True, index=True, nullable=False)
+    type: Mapped[PageType] = mapped_column(Enum(PageType), nullable=False)
+    status: Mapped[PageStatus] = mapped_column(
+        Enum(PageStatus),
+        default=PageStatus.DRAFT,
+        server_default=PageStatus.DRAFT.value,
+        nullable=False,
+    )
+    visibility: Mapped[Visibility] = mapped_column(Enum(Visibility), nullable=False)
+    current_draft_revision_id: Mapped[UUID | None] = mapped_column(
+        Uuid,
+        ForeignKey("revisions.id"),
+        nullable=True,
+    )
+    current_published_revision_id: Mapped[UUID | None] = mapped_column(
+        Uuid,
+        ForeignKey("revisions.id"),
+        nullable=True,
+    )
+    version: Mapped[int] = mapped_column(
+        Integer,
+        default=1,
+        server_default="1",
+        nullable=False,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        nullable=False,
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        onupdate=func.now(),
+        nullable=False,
+    )
+
+    revisions: Mapped[list[RevisionRecord]] = relationship(
+        back_populates="page",
+        foreign_keys="RevisionRecord.page_id",
+        cascade="all, delete-orphan",
+        order_by="RevisionRecord.created_at",
+    )
+    current_draft_revision: Mapped[RevisionRecord | None] = relationship(
+        foreign_keys=[current_draft_revision_id],
+        post_update=True,
+    )
+    current_published_revision: Mapped[RevisionRecord | None] = relationship(
+        foreign_keys=[current_published_revision_id],
+        post_update=True,
+    )
+
+
+class RevisionRecord(Base):
+    __tablename__ = "revisions"
+    __table_args__ = (
+        UniqueConstraint("page_id", "id", name="uq_revision_page_id_id"),
+    )
+
+    id: Mapped[UUID] = mapped_column(Uuid, primary_key=True, default=uuid4)
+    page_id: Mapped[UUID] = mapped_column(Uuid, ForeignKey("pages.id"), nullable=False, index=True)
+    parent_revision_id: Mapped[UUID | None] = mapped_column(
+        Uuid,
+        ForeignKey("revisions.id"),
+        nullable=True,
+    )
+    author_id: Mapped[UUID | None] = mapped_column(Uuid, nullable=True)
+    title: Mapped[str] = mapped_column(String(255), nullable=False)
+    summary: Mapped[str] = mapped_column(Text, nullable=False, default="", server_default="")
+    content: Mapped[str] = mapped_column(Text, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        nullable=False,
+    )
+
+    page: Mapped[PageRecord] = relationship(
+        back_populates="revisions",
+        foreign_keys=[page_id],
+    )
+    parent_revision: Mapped[RevisionRecord | None] = relationship(
+        remote_side=[id],
+        foreign_keys=[parent_revision_id],
+    )

--- a/services/encyclopedia/page_service.py
+++ b/services/encyclopedia/page_service.py
@@ -103,3 +103,48 @@ class PageService:
         except Exception:
             await self.session.rollback()
             raise
+
+    async def get_page_state(self, page_id: UUID) -> tuple[PageRecord, RevisionRecord | None, RevisionRecord | None]:
+        repository = PageRepository(self.session)
+        page = await repository.get_page(page_id)
+        if page is None:
+            raise PageNotFoundError(f"Page {page_id} was not found.")
+
+        current_draft_revision = None
+        if page.current_draft_revision_id is not None:
+            current_draft_revision = await repository.get_revision(page.current_draft_revision_id)
+
+        current_published_revision = None
+        if page.current_published_revision_id is not None:
+            current_published_revision = await repository.get_revision(page.current_published_revision_id)
+
+        return page, current_draft_revision, current_published_revision
+
+    async def list_page_revisions(self, page_id: UUID) -> tuple[PageRecord, list[RevisionRecord]]:
+        repository = PageRepository(self.session)
+        page = await repository.get_page(page_id)
+        if page is None:
+            raise PageNotFoundError(f"Page {page_id} was not found.")
+
+        revisions = await repository.list_revisions(page.id)
+        return page, revisions
+
+    async def get_page_revision(
+        self,
+        *,
+        page_id: UUID,
+        revision_id: UUID,
+    ) -> tuple[PageRecord, RevisionRecord, list[RevisionRecord]]:
+        repository = PageRepository(self.session)
+        page = await repository.get_page(page_id)
+        if page is None:
+            raise PageNotFoundError(f"Page {page_id} was not found.")
+
+        revision = await repository.get_revision_for_page(page_id=page.id, revision_id=revision_id)
+        if revision is None:
+            raise PageNotFoundError(
+                f"Revision {revision_id} was not found for page {page.id}."
+            )
+
+        lineage = await repository.get_revision_lineage(revision.id)
+        return page, revision, lineage

--- a/services/encyclopedia/page_service.py
+++ b/services/encyclopedia/page_service.py
@@ -32,6 +32,10 @@ class InvalidStatusTransitionError(Exception):
     pass
 
 
+class InvalidMetadataError(Exception):
+    pass
+
+
 ALLOWED_STATUS_TRANSITIONS = {
     PageStatus.DRAFT: {PageStatus.REVIEW, PageStatus.ARCHIVED, PageStatus.REDACTED},
     PageStatus.REVIEW: {PageStatus.DRAFT, PageStatus.ARCHIVED, PageStatus.REDACTED},
@@ -288,3 +292,88 @@ class PageService:
         except Exception:
             await self.session.rollback()
             raise
+
+    async def update_page_metadata(
+        self,
+        *,
+        page_id: UUID,
+        expected_page_version: int,
+        tags: list[str],
+        classifications: list[str],
+        related_page_ids: list[UUID],
+        media_asset_ids: list[UUID],
+    ) -> tuple[PageRecord, RevisionRecord | None, RevisionRecord | None]:
+        repository = PageRepository(self.session)
+        page = await repository.get_page(page_id)
+        if page is None:
+            raise PageNotFoundError(f"Page {page_id} was not found.")
+
+        normalized_tags = self._normalize_string_list(tags)
+        normalized_classifications = self._normalize_string_list(classifications)
+        unique_related_page_ids = self._dedupe_uuid_list(related_page_ids)
+        unique_media_asset_ids = self._dedupe_uuid_list(media_asset_ids)
+
+        if page.id in unique_related_page_ids:
+            raise InvalidMetadataError("A page cannot reference itself as a related page.")
+
+        if unique_related_page_ids:
+            related_pages = [
+                await repository.get_page(related_page_id)
+                for related_page_id in unique_related_page_ids
+            ]
+            missing_related_pages = [
+                str(related_page_id)
+                for related_page_id, related_page in zip(unique_related_page_ids, related_pages, strict=False)
+                if related_page is None
+            ]
+            if missing_related_pages:
+                raise InvalidMetadataError(
+                    f"Unknown related page IDs: {', '.join(missing_related_pages)}."
+                )
+
+        try:
+            page = await repository.replace_page_metadata(
+                page_id=page.id,
+                expected_version=expected_page_version,
+                tags=normalized_tags,
+                classifications=normalized_classifications,
+                related_page_ids=unique_related_page_ids,
+                media_asset_ids=unique_media_asset_ids,
+            )
+            await self.session.commit()
+            current_draft_revision = None
+            if page.current_draft_revision_id is not None:
+                current_draft_revision = await repository.get_revision(page.current_draft_revision_id)
+            current_published_revision = None
+            if page.current_published_revision_id is not None:
+                current_published_revision = await repository.get_revision(page.current_published_revision_id)
+            return page, current_draft_revision, current_published_revision
+        except StalePageVersionError:
+            await self.session.rollback()
+            raise
+        except Exception:
+            await self.session.rollback()
+            raise
+
+    @staticmethod
+    def _normalize_string_list(values: list[str]) -> list[str]:
+        seen: set[str] = set()
+        normalized: list[str] = []
+        for value in values:
+            stripped = value.strip()
+            if not stripped or stripped in seen:
+                continue
+            seen.add(stripped)
+            normalized.append(stripped)
+        return normalized
+
+    @staticmethod
+    def _dedupe_uuid_list(values: list[UUID]) -> list[UUID]:
+        deduped: list[UUID] = []
+        seen: set[UUID] = set()
+        for value in values:
+            if value in seen:
+                continue
+            seen.add(value)
+            deduped.append(value)
+        return deduped

--- a/services/encyclopedia/page_service.py
+++ b/services/encyclopedia/page_service.py
@@ -7,7 +7,13 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from domain import PageStatus
 from models import PageRecord, RevisionRecord
 from repository import PageRepository, StalePageVersionError
-from schemas import CreateDraftRevisionRequest, CreatePageRequest
+from schemas import (
+    CreateDraftRevisionRequest,
+    CreatePageRequest,
+    PublishRevisionRequest,
+    RevertRevisionRequest,
+    TransitionPageStatusRequest,
+)
 
 
 class PageAlreadyExistsError(Exception):
@@ -20,6 +26,19 @@ class PageNotFoundError(Exception):
 
 class InvalidParentRevisionError(Exception):
     pass
+
+
+class InvalidStatusTransitionError(Exception):
+    pass
+
+
+ALLOWED_STATUS_TRANSITIONS = {
+    PageStatus.DRAFT: {PageStatus.REVIEW, PageStatus.ARCHIVED, PageStatus.REDACTED},
+    PageStatus.REVIEW: {PageStatus.DRAFT, PageStatus.ARCHIVED, PageStatus.REDACTED},
+    PageStatus.PUBLISHED: {PageStatus.DRAFT, PageStatus.ARCHIVED, PageStatus.REDACTED},
+    PageStatus.ARCHIVED: {PageStatus.DRAFT, PageStatus.REDACTED},
+    PageStatus.REDACTED: set(),
+}
 
 
 @dataclass
@@ -148,3 +167,124 @@ class PageService:
 
         lineage = await repository.get_revision_lineage(revision.id)
         return page, revision, lineage
+
+    async def publish_revision(
+        self,
+        *,
+        page_id: UUID,
+        payload: PublishRevisionRequest,
+    ) -> tuple[PageRecord, RevisionRecord | None, RevisionRecord | None]:
+        repository = PageRepository(self.session)
+        page = await repository.get_page(page_id)
+        if page is None:
+            raise PageNotFoundError(f"Page {page_id} was not found.")
+
+        revision = await repository.get_revision_for_page(
+            page_id=page.id,
+            revision_id=payload.revision_id,
+        )
+        if revision is None:
+            raise PageNotFoundError(
+                f"Revision {payload.revision_id} was not found for page {page.id}."
+            )
+
+        try:
+            page = await repository.update_page_state(
+                page_id=page.id,
+                expected_version=payload.expected_page_version,
+                current_published_revision_id=revision.id,
+                status=PageStatus.PUBLISHED,
+            )
+            await self.session.commit()
+            current_draft_revision = None
+            if page.current_draft_revision_id is not None:
+                current_draft_revision = await repository.get_revision(page.current_draft_revision_id)
+            return page, current_draft_revision, revision
+        except StalePageVersionError:
+            await self.session.rollback()
+            raise
+        except Exception:
+            await self.session.rollback()
+            raise
+
+    async def revert_to_revision(
+        self,
+        *,
+        page_id: UUID,
+        payload: RevertRevisionRequest,
+    ) -> tuple[PageRecord, RevisionRecord]:
+        repository = PageRepository(self.session)
+        page = await repository.get_page(page_id)
+        if page is None:
+            raise PageNotFoundError(f"Page {page_id} was not found.")
+
+        target_revision = await repository.get_revision_for_page(
+            page_id=page.id,
+            revision_id=payload.revision_id,
+        )
+        if target_revision is None:
+            raise PageNotFoundError(
+                f"Revision {payload.revision_id} was not found for page {page.id}."
+            )
+
+        try:
+            revision = await repository.create_revision(
+                page_id=page.id,
+                parent_revision_id=target_revision.id,
+                title=target_revision.title,
+                summary=target_revision.summary,
+                content=target_revision.content,
+                author_id=payload.author_id,
+            )
+            page = await repository.update_page_state(
+                page_id=page.id,
+                expected_version=payload.expected_page_version,
+                current_draft_revision_id=revision.id,
+                status=PageStatus.DRAFT,
+            )
+            await self.session.commit()
+            await self.session.refresh(revision)
+            return page, revision
+        except StalePageVersionError:
+            await self.session.rollback()
+            raise
+        except Exception:
+            await self.session.rollback()
+            raise
+
+    async def transition_page_status(
+        self,
+        *,
+        page_id: UUID,
+        payload: TransitionPageStatusRequest,
+    ) -> tuple[PageRecord, RevisionRecord | None, RevisionRecord | None]:
+        repository = PageRepository(self.session)
+        page = await repository.get_page(page_id)
+        if page is None:
+            raise PageNotFoundError(f"Page {page_id} was not found.")
+
+        if payload.status not in ALLOWED_STATUS_TRANSITIONS[page.status]:
+            raise InvalidStatusTransitionError(
+                f"Status transition from {page.status.value} to {payload.status.value} is not allowed."
+            )
+
+        try:
+            page = await repository.update_page_state(
+                page_id=page.id,
+                expected_version=payload.expected_page_version,
+                status=payload.status,
+            )
+            await self.session.commit()
+            current_draft_revision = None
+            if page.current_draft_revision_id is not None:
+                current_draft_revision = await repository.get_revision(page.current_draft_revision_id)
+            current_published_revision = None
+            if page.current_published_revision_id is not None:
+                current_published_revision = await repository.get_revision(page.current_published_revision_id)
+            return page, current_draft_revision, current_published_revision
+        except StalePageVersionError:
+            await self.session.rollback()
+            raise
+        except Exception:
+            await self.session.rollback()
+            raise

--- a/services/encyclopedia/page_service.py
+++ b/services/encyclopedia/page_service.py
@@ -1,0 +1,105 @@
+from dataclasses import dataclass
+from uuid import UUID
+
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from domain import PageStatus
+from models import PageRecord, RevisionRecord
+from repository import PageRepository, StalePageVersionError
+from schemas import CreateDraftRevisionRequest, CreatePageRequest
+
+
+class PageAlreadyExistsError(Exception):
+    pass
+
+
+class PageNotFoundError(Exception):
+    pass
+
+
+class InvalidParentRevisionError(Exception):
+    pass
+
+
+@dataclass
+class PageService:
+    session: AsyncSession
+
+    async def create_page(self, payload: CreatePageRequest) -> tuple[PageRecord, RevisionRecord]:
+        repository = PageRepository(self.session)
+        try:
+            page = await repository.create_page(
+                slug=payload.slug,
+                page_type=payload.type,
+                visibility=payload.visibility,
+            )
+            revision = await repository.create_revision(
+                page_id=page.id,
+                title=payload.title,
+                summary=payload.summary,
+                content=payload.content,
+                author_id=payload.author_id,
+            )
+            page = await repository.update_page_state(
+                page_id=page.id,
+                expected_version=page.version,
+                current_draft_revision_id=revision.id,
+            )
+            await self.session.commit()
+            await self.session.refresh(revision)
+            return page, revision
+        except IntegrityError as exc:
+            await self.session.rollback()
+            raise PageAlreadyExistsError(
+                f"Page with slug '{payload.slug}' already exists."
+            ) from exc
+        except Exception:
+            await self.session.rollback()
+            raise
+
+    async def create_draft_revision(
+        self,
+        *,
+        page_id: UUID,
+        payload: CreateDraftRevisionRequest,
+    ) -> tuple[PageRecord, RevisionRecord]:
+        repository = PageRepository(self.session)
+        page = await repository.get_page(page_id)
+        if page is None:
+            raise PageNotFoundError(f"Page {page_id} was not found.")
+
+        parent_revision_id = payload.parent_revision_id or page.current_draft_revision_id
+        if parent_revision_id is None:
+            parent_revision_id = page.current_published_revision_id
+        if parent_revision_id is not None:
+            parent_revision = await repository.get_revision(parent_revision_id)
+            if parent_revision is None or parent_revision.page_id != page.id:
+                raise InvalidParentRevisionError(
+                    f"Revision {parent_revision_id} cannot be used as a parent for page {page.id}."
+                )
+
+        try:
+            revision = await repository.create_revision(
+                page_id=page.id,
+                parent_revision_id=parent_revision_id,
+                title=payload.title,
+                summary=payload.summary,
+                content=payload.content,
+                author_id=payload.author_id,
+            )
+            page = await repository.update_page_state(
+                page_id=page.id,
+                expected_version=payload.expected_page_version,
+                current_draft_revision_id=revision.id,
+                status=PageStatus.DRAFT,
+            )
+            await self.session.commit()
+            await self.session.refresh(revision)
+            return page, revision
+        except StalePageVersionError:
+            await self.session.rollback()
+            raise
+        except Exception:
+            await self.session.rollback()
+            raise

--- a/services/encyclopedia/pytest.ini
+++ b/services/encyclopedia/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+asyncio_mode = auto

--- a/services/encyclopedia/repository.py
+++ b/services/encyclopedia/repository.py
@@ -1,0 +1,120 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Final
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from domain import PageStatus, PageType, Visibility
+from models import PageRecord, RevisionRecord
+
+UNSET: Final = object()
+
+
+class StalePageVersionError(Exception):
+    pass
+
+
+@dataclass
+class PageRepository:
+    session: AsyncSession
+
+    async def create_page(
+        self,
+        *,
+        slug: str,
+        page_type: PageType,
+        visibility: Visibility,
+        status: PageStatus = PageStatus.DRAFT,
+    ) -> PageRecord:
+        page = PageRecord(
+            slug=slug,
+            type=page_type,
+            visibility=visibility,
+            status=status,
+        )
+        self.session.add(page)
+        await self.session.flush()
+        return page
+
+    async def create_revision(
+        self,
+        *,
+        page_id: UUID,
+        title: str,
+        summary: str,
+        content: str,
+        parent_revision_id: UUID | None = None,
+        author_id: UUID | None = None,
+    ) -> RevisionRecord:
+        revision = RevisionRecord(
+            page_id=page_id,
+            parent_revision_id=parent_revision_id,
+            author_id=author_id,
+            title=title,
+            summary=summary,
+            content=content,
+        )
+        self.session.add(revision)
+        await self.session.flush()
+        return revision
+
+    async def get_page(self, page_id: UUID) -> PageRecord | None:
+        return await self.session.get(PageRecord, page_id)
+
+    async def get_page_by_slug(self, slug: str) -> PageRecord | None:
+        result = await self.session.execute(
+            select(PageRecord).where(PageRecord.slug == slug)
+        )
+        return result.scalar_one_or_none()
+
+    async def get_revision(self, revision_id: UUID) -> RevisionRecord | None:
+        return await self.session.get(RevisionRecord, revision_id)
+
+    async def list_revisions(self, page_id: UUID) -> list[RevisionRecord]:
+        result = await self.session.execute(
+            select(RevisionRecord)
+            .where(RevisionRecord.page_id == page_id)
+            .order_by(RevisionRecord.created_at, RevisionRecord.id)
+        )
+        return list(result.scalars())
+
+    async def get_revision_lineage(self, revision_id: UUID) -> list[RevisionRecord]:
+        lineage: list[RevisionRecord] = []
+        current = await self.get_revision(revision_id)
+        while current is not None:
+            lineage.append(current)
+            if current.parent_revision_id is None:
+                break
+            current = await self.get_revision(current.parent_revision_id)
+        return lineage
+
+    async def update_page_state(
+        self,
+        *,
+        page_id: UUID,
+        expected_version: int,
+        current_draft_revision_id: UUID | None | object = UNSET,
+        current_published_revision_id: UUID | None | object = UNSET,
+        status: PageStatus | object = UNSET,
+    ) -> PageRecord:
+        page = await self.get_page(page_id)
+        if page is None:
+            raise LookupError(f"Page {page_id} was not found.")
+        if page.version != expected_version:
+            raise StalePageVersionError(
+                f"Expected page version {expected_version}, found {page.version}."
+            )
+
+        if current_draft_revision_id is not UNSET:
+            page.current_draft_revision_id = current_draft_revision_id
+        if current_published_revision_id is not UNSET:
+            page.current_published_revision_id = current_published_revision_id
+        if status is not UNSET:
+            page.status = status
+
+        page.version += 1
+        await self.session.flush()
+        return page

--- a/services/encyclopedia/repository.py
+++ b/services/encyclopedia/repository.py
@@ -73,6 +73,20 @@ class PageRepository:
     async def get_revision(self, revision_id: UUID) -> RevisionRecord | None:
         return await self.session.get(RevisionRecord, revision_id)
 
+    async def get_revision_for_page(
+        self,
+        *,
+        page_id: UUID,
+        revision_id: UUID,
+    ) -> RevisionRecord | None:
+        result = await self.session.execute(
+            select(RevisionRecord).where(
+                RevisionRecord.id == revision_id,
+                RevisionRecord.page_id == page_id,
+            )
+        )
+        return result.scalar_one_or_none()
+
     async def list_revisions(self, page_id: UUID) -> list[RevisionRecord]:
         result = await self.session.execute(
             select(RevisionRecord)

--- a/services/encyclopedia/repository.py
+++ b/services/encyclopedia/repository.py
@@ -6,9 +6,10 @@ from uuid import UUID
 
 from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
 from domain import PageStatus, PageType, Visibility
-from models import PageRecord, RevisionRecord
+from models import PageMediaReferenceRecord, PageRecord, PageRelationshipRecord, RevisionRecord
 
 UNSET: Final = object()
 
@@ -20,6 +21,12 @@ class StalePageVersionError(Exception):
 @dataclass
 class PageRepository:
     session: AsyncSession
+
+    def _page_query(self):
+        return select(PageRecord).options(
+            selectinload(PageRecord.related_pages),
+            selectinload(PageRecord.media_references),
+        )
 
     async def create_page(
         self,
@@ -62,11 +69,14 @@ class PageRepository:
         return revision
 
     async def get_page(self, page_id: UUID) -> PageRecord | None:
-        return await self.session.get(PageRecord, page_id)
+        result = await self.session.execute(
+            self._page_query().where(PageRecord.id == page_id)
+        )
+        return result.scalar_one_or_none()
 
     async def get_page_by_slug(self, slug: str) -> PageRecord | None:
         result = await self.session.execute(
-            select(PageRecord).where(PageRecord.slug == slug)
+            self._page_query().where(PageRecord.slug == slug)
         )
         return result.scalar_one_or_none()
 
@@ -142,7 +152,37 @@ class PageRepository:
             )
 
         await self.session.flush()
-        updated_page = await self.session.get(PageRecord, page_id, populate_existing=True)
+        updated_page = await self.get_page(page_id)
         if updated_page is None:
             raise LookupError(f"Page {page_id} was not found after update.")
         return updated_page
+
+    async def replace_page_metadata(
+        self,
+        *,
+        page_id: UUID,
+        expected_version: int,
+        tags: list[str],
+        classifications: list[str],
+        related_page_ids: list[UUID],
+        media_asset_ids: list[UUID],
+    ) -> PageRecord:
+        page = await self.get_page(page_id)
+        if page is None:
+            raise LookupError(f"Page {page_id} was not found.")
+
+        page.tags = tags
+        page.classifications = classifications
+        page.related_pages = [
+            PageRelationshipRecord(target_page_id=target_page_id)
+            for target_page_id in related_page_ids
+        ]
+        page.media_references = [
+            PageMediaReferenceRecord(asset_id=asset_id)
+            for asset_id in media_asset_ids
+        ]
+
+        return await self.update_page_state(
+            page_id=page_id,
+            expected_version=expected_version,
+        )

--- a/services/encyclopedia/repository.py
+++ b/services/encyclopedia/repository.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass
 from typing import Final
 from uuid import UUID
 
-from sqlalchemy import select
+from sqlalchemy import select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from domain import PageStatus, PageType, Visibility
@@ -103,18 +103,32 @@ class PageRepository:
         page = await self.get_page(page_id)
         if page is None:
             raise LookupError(f"Page {page_id} was not found.")
-        if page.version != expected_version:
+
+        values: dict[str, object] = {"version": PageRecord.version + 1}
+        if current_draft_revision_id is not UNSET:
+            values["current_draft_revision_id"] = current_draft_revision_id
+        if current_published_revision_id is not UNSET:
+            values["current_published_revision_id"] = current_published_revision_id
+        if status is not UNSET:
+            values["status"] = status
+
+        result = await self.session.execute(
+            update(PageRecord)
+            .where(
+                PageRecord.id == page_id,
+                PageRecord.version == expected_version,
+            )
+            .values(**values)
+        )
+        if result.rowcount != 1:
+            current_page = await self.get_page(page_id)
+            current_version = current_page.version if current_page is not None else "missing"
             raise StalePageVersionError(
-                f"Expected page version {expected_version}, found {page.version}."
+                f"Expected page version {expected_version}, found {current_version}."
             )
 
-        if current_draft_revision_id is not UNSET:
-            page.current_draft_revision_id = current_draft_revision_id
-        if current_published_revision_id is not UNSET:
-            page.current_published_revision_id = current_published_revision_id
-        if status is not UNSET:
-            page.status = status
-
-        page.version += 1
         await self.session.flush()
-        return page
+        updated_page = await self.session.get(PageRecord, page_id, populate_existing=True)
+        if updated_page is None:
+            raise LookupError(f"Page {page_id} was not found after update.")
+        return updated_page

--- a/services/encyclopedia/requirements.txt
+++ b/services/encyclopedia/requirements.txt
@@ -1,0 +1,10 @@
+fastapi==0.111.0
+pydantic-settings==2.3.4
+sqlalchemy==2.0.36
+greenlet==3.2.4
+asyncpg==0.29.0
+aiosqlite==0.20.0
+httpx==0.27.0
+pytest==9.0.3
+pytest-asyncio==1.3.0
+uvicorn[standard]==0.30.1

--- a/services/encyclopedia/routes/health.py
+++ b/services/encyclopedia/routes/health.py
@@ -1,0 +1,32 @@
+from fastapi import APIRouter, Depends, HTTPException
+
+from config import Settings, get_settings
+from db import check_database_connection
+
+router = APIRouter(tags=["health"])
+
+
+@router.get("/health")
+async def healthcheck() -> dict[str, str]:
+    return {"status": "ok"}
+
+
+@router.get("/ready")
+async def readiness(settings: Settings = Depends(get_settings)) -> dict[str, object]:
+    try:
+        await check_database_connection()
+    except Exception as exc:
+        raise HTTPException(
+            status_code=503,
+            detail={
+                "status": "error",
+                "services": {"database": "unavailable"},
+                "database_url": settings.database_url,
+            },
+        ) from exc
+
+    return {
+        "status": "ok",
+        "services": {"database": "ok"},
+        "database_url": settings.database_url,
+    }

--- a/services/encyclopedia/routes/pages.py
+++ b/services/encyclopedia/routes/pages.py
@@ -5,6 +5,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from db import get_async_session
 from page_service import (
+    InvalidMetadataError,
     InvalidParentRevisionError,
     InvalidStatusTransitionError,
     PageAlreadyExistsError,
@@ -22,6 +23,7 @@ from schemas import (
     RevertRevisionRequest,
     RevisionDetailResponse,
     TransitionPageStatusRequest,
+    UpdatePageMetadataRequest,
 )
 
 router = APIRouter(prefix="/pages", tags=["pages"])
@@ -74,6 +76,36 @@ async def get_page_state(
         page, current_draft_revision, current_published_revision = await service.get_page_state(page_id)
     except PageNotFoundError as exc:
         raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+    return PageStateResponse(
+        page=page,
+        current_draft_revision=current_draft_revision,
+        current_published_revision=current_published_revision,
+    )
+
+
+@router.put("/{page_id}/metadata", response_model=PageStateResponse)
+async def update_page_metadata(
+    page_id: UUID,
+    payload: UpdatePageMetadataRequest,
+    session: AsyncSession = Depends(get_async_session),
+) -> PageStateResponse:
+    service = PageService(session)
+    try:
+        page, current_draft_revision, current_published_revision = await service.update_page_metadata(
+            page_id=page_id,
+            expected_page_version=payload.expected_page_version,
+            tags=payload.tags,
+            classifications=payload.classifications,
+            related_page_ids=payload.related_page_ids,
+            media_asset_ids=payload.media_asset_ids,
+        )
+    except PageNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except InvalidMetadataError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except StalePageVersionError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
 
     return PageStateResponse(
         page=page,

--- a/services/encyclopedia/routes/pages.py
+++ b/services/encyclopedia/routes/pages.py
@@ -11,7 +11,14 @@ from page_service import (
     PageService,
 )
 from repository import StalePageVersionError
-from schemas import CreateDraftRevisionRequest, CreatePageRequest, PageDraftResponse
+from schemas import (
+    CreateDraftRevisionRequest,
+    CreatePageRequest,
+    PageDraftResponse,
+    PageRevisionListResponse,
+    PageStateResponse,
+    RevisionDetailResponse,
+)
 
 router = APIRouter(prefix="/pages", tags=["pages"])
 
@@ -51,3 +58,56 @@ async def create_draft_revision(
         raise HTTPException(status_code=409, detail=str(exc)) from exc
 
     return PageDraftResponse(page=page, revision=revision)
+
+
+@router.get("/{page_id}", response_model=PageStateResponse)
+async def get_page_state(
+    page_id: UUID,
+    session: AsyncSession = Depends(get_async_session),
+) -> PageStateResponse:
+    service = PageService(session)
+    try:
+        page, current_draft_revision, current_published_revision = await service.get_page_state(page_id)
+    except PageNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+    return PageStateResponse(
+        page=page,
+        current_draft_revision=current_draft_revision,
+        current_published_revision=current_published_revision,
+    )
+
+
+@router.get("/{page_id}/revisions", response_model=PageRevisionListResponse)
+async def list_page_revisions(
+    page_id: UUID,
+    session: AsyncSession = Depends(get_async_session),
+) -> PageRevisionListResponse:
+    service = PageService(session)
+    try:
+        page, revisions = await service.list_page_revisions(page_id)
+    except PageNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+    return PageRevisionListResponse(page=page, revisions=revisions)
+
+
+@router.get(
+    "/{page_id}/revisions/{revision_id}",
+    response_model=RevisionDetailResponse,
+)
+async def get_page_revision(
+    page_id: UUID,
+    revision_id: UUID,
+    session: AsyncSession = Depends(get_async_session),
+) -> RevisionDetailResponse:
+    service = PageService(session)
+    try:
+        page, revision, lineage = await service.get_page_revision(
+            page_id=page_id,
+            revision_id=revision_id,
+        )
+    except PageNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+    return RevisionDetailResponse(page=page, revision=revision, lineage=lineage)

--- a/services/encyclopedia/routes/pages.py
+++ b/services/encyclopedia/routes/pages.py
@@ -6,6 +6,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from db import get_async_session
 from page_service import (
     InvalidParentRevisionError,
+    InvalidStatusTransitionError,
     PageAlreadyExistsError,
     PageNotFoundError,
     PageService,
@@ -17,7 +18,10 @@ from schemas import (
     PageDraftResponse,
     PageRevisionListResponse,
     PageStateResponse,
+    PublishRevisionRequest,
+    RevertRevisionRequest,
     RevisionDetailResponse,
+    TransitionPageStatusRequest,
 )
 
 router = APIRouter(prefix="/pages", tags=["pages"])
@@ -111,3 +115,70 @@ async def get_page_revision(
         raise HTTPException(status_code=404, detail=str(exc)) from exc
 
     return RevisionDetailResponse(page=page, revision=revision, lineage=lineage)
+
+
+@router.post("/{page_id}/publish", response_model=PageStateResponse)
+async def publish_revision(
+    page_id: UUID,
+    payload: PublishRevisionRequest,
+    session: AsyncSession = Depends(get_async_session),
+) -> PageStateResponse:
+    service = PageService(session)
+    try:
+        page, current_draft_revision, current_published_revision = await service.publish_revision(
+            page_id=page_id,
+            payload=payload,
+        )
+    except PageNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except StalePageVersionError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+
+    return PageStateResponse(
+        page=page,
+        current_draft_revision=current_draft_revision,
+        current_published_revision=current_published_revision,
+    )
+
+
+@router.post("/{page_id}/revert", response_model=PageDraftResponse, status_code=status.HTTP_201_CREATED)
+async def revert_revision(
+    page_id: UUID,
+    payload: RevertRevisionRequest,
+    session: AsyncSession = Depends(get_async_session),
+) -> PageDraftResponse:
+    service = PageService(session)
+    try:
+        page, revision = await service.revert_to_revision(page_id=page_id, payload=payload)
+    except PageNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except StalePageVersionError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+
+    return PageDraftResponse(page=page, revision=revision)
+
+
+@router.post("/{page_id}/status", response_model=PageStateResponse)
+async def transition_page_status(
+    page_id: UUID,
+    payload: TransitionPageStatusRequest,
+    session: AsyncSession = Depends(get_async_session),
+) -> PageStateResponse:
+    service = PageService(session)
+    try:
+        page, current_draft_revision, current_published_revision = await service.transition_page_status(
+            page_id=page_id,
+            payload=payload,
+        )
+    except PageNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except InvalidStatusTransitionError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except StalePageVersionError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+
+    return PageStateResponse(
+        page=page,
+        current_draft_revision=current_draft_revision,
+        current_published_revision=current_published_revision,
+    )

--- a/services/encyclopedia/routes/pages.py
+++ b/services/encyclopedia/routes/pages.py
@@ -1,0 +1,53 @@
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from db import get_async_session
+from page_service import (
+    InvalidParentRevisionError,
+    PageAlreadyExistsError,
+    PageNotFoundError,
+    PageService,
+)
+from repository import StalePageVersionError
+from schemas import CreateDraftRevisionRequest, CreatePageRequest, PageDraftResponse
+
+router = APIRouter(prefix="/pages", tags=["pages"])
+
+
+@router.post("", response_model=PageDraftResponse, status_code=status.HTTP_201_CREATED)
+async def create_page(
+    payload: CreatePageRequest,
+    session: AsyncSession = Depends(get_async_session),
+) -> PageDraftResponse:
+    service = PageService(session)
+    try:
+        page, revision = await service.create_page(payload)
+    except PageAlreadyExistsError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+
+    return PageDraftResponse(page=page, revision=revision)
+
+
+@router.post(
+    "/{page_id}/drafts",
+    response_model=PageDraftResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+async def create_draft_revision(
+    page_id: UUID,
+    payload: CreateDraftRevisionRequest,
+    session: AsyncSession = Depends(get_async_session),
+) -> PageDraftResponse:
+    service = PageService(session)
+    try:
+        page, revision = await service.create_draft_revision(page_id=page_id, payload=payload)
+    except PageNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except InvalidParentRevisionError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except StalePageVersionError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+
+    return PageDraftResponse(page=page, revision=revision)

--- a/services/encyclopedia/schemas.py
+++ b/services/encyclopedia/schemas.py
@@ -25,6 +25,22 @@ class CreateDraftRevisionRequest(BaseModel):
     parent_revision_id: UUID | None = None
 
 
+class PublishRevisionRequest(BaseModel):
+    expected_page_version: int = Field(ge=1)
+    revision_id: UUID
+
+
+class RevertRevisionRequest(BaseModel):
+    expected_page_version: int = Field(ge=1)
+    revision_id: UUID
+    author_id: UUID | None = None
+
+
+class TransitionPageStatusRequest(BaseModel):
+    expected_page_version: int = Field(ge=1)
+    status: PageStatus
+
+
 class PageResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 

--- a/services/encyclopedia/schemas.py
+++ b/services/encyclopedia/schemas.py
@@ -41,6 +41,14 @@ class TransitionPageStatusRequest(BaseModel):
     status: PageStatus
 
 
+class UpdatePageMetadataRequest(BaseModel):
+    expected_page_version: int = Field(ge=1)
+    tags: list[str] = Field(default_factory=list)
+    classifications: list[str] = Field(default_factory=list)
+    related_page_ids: list[UUID] = Field(default_factory=list)
+    media_asset_ids: list[UUID] = Field(default_factory=list)
+
+
 class PageResponse(BaseModel):
     model_config = ConfigDict(from_attributes=True)
 
@@ -52,6 +60,10 @@ class PageResponse(BaseModel):
     current_draft_revision_id: UUID | None
     current_published_revision_id: UUID | None
     version: int
+    tags: list[str]
+    classifications: list[str]
+    related_page_ids: list[UUID]
+    media_asset_ids: list[UUID]
     created_at: datetime
     updated_at: datetime
 

--- a/services/encyclopedia/schemas.py
+++ b/services/encyclopedia/schemas.py
@@ -1,0 +1,58 @@
+from datetime import datetime
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from domain import PageStatus, PageType, Visibility
+
+
+class CreatePageRequest(BaseModel):
+    slug: str = Field(min_length=1, max_length=255)
+    type: PageType
+    visibility: Visibility
+    title: str = Field(min_length=1, max_length=255)
+    summary: str = ""
+    content: str = Field(min_length=1)
+    author_id: UUID | None = None
+
+
+class CreateDraftRevisionRequest(BaseModel):
+    expected_page_version: int = Field(ge=1)
+    title: str = Field(min_length=1, max_length=255)
+    summary: str = ""
+    content: str = Field(min_length=1)
+    author_id: UUID | None = None
+    parent_revision_id: UUID | None = None
+
+
+class PageResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    slug: str
+    type: PageType
+    status: PageStatus
+    visibility: Visibility
+    current_draft_revision_id: UUID | None
+    current_published_revision_id: UUID | None
+    version: int
+    created_at: datetime
+    updated_at: datetime
+
+
+class RevisionResponse(BaseModel):
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    page_id: UUID
+    parent_revision_id: UUID | None
+    author_id: UUID | None
+    title: str
+    summary: str
+    content: str
+    created_at: datetime
+
+
+class PageDraftResponse(BaseModel):
+    page: PageResponse
+    revision: RevisionResponse

--- a/services/encyclopedia/schemas.py
+++ b/services/encyclopedia/schemas.py
@@ -56,3 +56,20 @@ class RevisionResponse(BaseModel):
 class PageDraftResponse(BaseModel):
     page: PageResponse
     revision: RevisionResponse
+
+
+class PageStateResponse(BaseModel):
+    page: PageResponse
+    current_draft_revision: RevisionResponse | None
+    current_published_revision: RevisionResponse | None
+
+
+class PageRevisionListResponse(BaseModel):
+    page: PageResponse
+    revisions: list[RevisionResponse]
+
+
+class RevisionDetailResponse(BaseModel):
+    page: PageResponse
+    revision: RevisionResponse
+    lineage: list[RevisionResponse]

--- a/services/encyclopedia/tests/test_health.py
+++ b/services/encyclopedia/tests/test_health.py
@@ -1,0 +1,43 @@
+from httpx import ASGITransport, AsyncClient
+
+from config import get_settings
+from db import reset_database_state
+from main import create_app
+
+
+def reset_caches() -> None:
+    get_settings.cache_clear()
+    reset_database_state()
+
+
+async def test_healthcheck() -> None:
+    app = create_app()
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        response = await client.get("/health")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "ok"}
+
+
+async def test_readiness_checks_database(monkeypatch) -> None:
+    monkeypatch.setenv("ENCYCLOPEDIA_SERVICE_DATABASE_URL", "sqlite+aiosqlite:///:memory:")
+    reset_caches()
+    app = create_app()
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        response = await client.get("/ready")
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "status": "ok",
+        "services": {"database": "ok"},
+        "database_url": "sqlite+aiosqlite:///:memory:",
+    }
+
+    reset_caches()

--- a/services/encyclopedia/tests/test_lifecycle.py
+++ b/services/encyclopedia/tests/test_lifecycle.py
@@ -1,0 +1,142 @@
+from pathlib import Path
+
+from httpx import ASGITransport, AsyncClient
+
+from config import get_settings
+from db import get_engine, reset_database_state
+from main import create_app
+from models import Base
+
+
+async def create_test_app(tmp_path: Path, monkeypatch) -> object:
+    database_path = tmp_path / "encyclopedia-lifecycle-test.db"
+    monkeypatch.setenv(
+        "ENCYCLOPEDIA_SERVICE_DATABASE_URL",
+        f"sqlite+aiosqlite:///{database_path}",
+    )
+    get_settings.cache_clear()
+    reset_database_state()
+
+    app = create_app()
+    async with get_engine().begin() as connection:
+        await connection.run_sync(Base.metadata.create_all)
+    return app
+
+
+async def seed_page_with_two_revisions(client: AsyncClient) -> tuple[dict, dict]:
+    create_response = await client.post(
+        "/pages",
+        json={
+            "slug": "bloodsucker-dossier",
+            "type": "Article",
+            "visibility": "Internal",
+            "title": "Bloodsucker Dossier",
+            "summary": "First draft.",
+            "content": "Initial content.",
+        },
+    )
+    create_body = create_response.json()
+    edit_response = await client.post(
+        f"/pages/{create_body['page']['id']}/drafts",
+        json={
+            "expected_page_version": create_body["page"]["version"],
+            "title": "Bloodsucker Dossier",
+            "summary": "Second draft.",
+            "content": "Updated content.",
+        },
+    )
+    return create_body, edit_response.json()
+
+
+async def test_publish_preserves_draft_history_and_sets_published_pointer(tmp_path, monkeypatch) -> None:
+    app = await create_test_app(tmp_path, monkeypatch)
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        create_body, edit_body = await seed_page_with_two_revisions(client)
+        response = await client.post(
+            f"/pages/{create_body['page']['id']}/publish",
+            json={
+                "expected_page_version": edit_body["page"]["version"],
+                "revision_id": create_body["revision"]["id"],
+            },
+        )
+
+    body = response.json()
+    assert response.status_code == 200
+    assert body["page"]["status"] == "Published"
+    assert body["page"]["current_published_revision_id"] == create_body["revision"]["id"]
+    assert body["page"]["current_draft_revision_id"] == edit_body["revision"]["id"]
+    assert body["current_published_revision"]["id"] == create_body["revision"]["id"]
+    assert body["current_draft_revision"]["id"] == edit_body["revision"]["id"]
+
+
+async def test_revert_creates_new_revision_derived_from_old_revision(tmp_path, monkeypatch) -> None:
+    app = await create_test_app(tmp_path, monkeypatch)
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        create_body, edit_body = await seed_page_with_two_revisions(client)
+        publish_response = await client.post(
+            f"/pages/{create_body['page']['id']}/publish",
+            json={
+                "expected_page_version": edit_body["page"]["version"],
+                "revision_id": create_body["revision"]["id"],
+            },
+        )
+        publish_body = publish_response.json()
+        revert_response = await client.post(
+            f"/pages/{create_body['page']['id']}/revert",
+            json={
+                "expected_page_version": publish_body["page"]["version"],
+                "revision_id": create_body["revision"]["id"],
+            },
+        )
+
+    body = revert_response.json()
+    assert revert_response.status_code == 201
+    assert body["page"]["status"] == "Draft"
+    assert body["page"]["current_draft_revision_id"] == body["revision"]["id"]
+    assert body["revision"]["parent_revision_id"] == create_body["revision"]["id"]
+    assert body["revision"]["content"] == create_body["revision"]["content"]
+
+
+async def test_status_transitions_are_explicit_and_reject_invalid_moves(tmp_path, monkeypatch) -> None:
+    app = await create_test_app(tmp_path, monkeypatch)
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        create_response = await client.post(
+            "/pages",
+            json={
+                "slug": "controller-report",
+                "type": "Incident",
+                "visibility": "Internal",
+                "title": "Controller Report",
+                "summary": "Initial draft.",
+                "content": "Initial content.",
+            },
+        )
+        create_body = create_response.json()
+        review_response = await client.post(
+            f"/pages/{create_body['page']['id']}/status",
+            json={
+                "expected_page_version": create_body["page"]["version"],
+                "status": "Review",
+            },
+        )
+        invalid_response = await client.post(
+            f"/pages/{create_body['page']['id']}/status",
+            json={
+                "expected_page_version": review_response.json()["page"]["version"],
+                "status": "Published",
+            },
+        )
+
+    assert review_response.status_code == 200
+    assert review_response.json()["page"]["status"] == "Review"
+    assert invalid_response.status_code == 400
+    assert "not allowed" in invalid_response.json()["detail"]

--- a/services/encyclopedia/tests/test_metadata.py
+++ b/services/encyclopedia/tests/test_metadata.py
@@ -1,0 +1,120 @@
+from pathlib import Path
+from uuid import uuid4
+
+from httpx import ASGITransport, AsyncClient
+
+from config import get_settings
+from db import get_engine, reset_database_state
+from main import create_app
+from models import Base
+
+
+async def create_test_app(tmp_path: Path, monkeypatch) -> object:
+    database_path = tmp_path / "encyclopedia-metadata-test.db"
+    monkeypatch.setenv(
+        "ENCYCLOPEDIA_SERVICE_DATABASE_URL",
+        f"sqlite+aiosqlite:///{database_path}",
+    )
+    get_settings.cache_clear()
+    reset_database_state()
+
+    app = create_app()
+    async with get_engine().begin() as connection:
+        await connection.run_sync(Base.metadata.create_all)
+    return app
+
+
+async def create_page(client: AsyncClient, slug: str) -> dict:
+    response = await client.post(
+        "/pages",
+        json={
+            "slug": slug,
+            "type": "Article",
+            "visibility": "Internal",
+            "title": slug.replace("-", " ").title(),
+            "summary": "Summary",
+            "content": "Content",
+        },
+    )
+    return response.json()
+
+
+async def test_metadata_update_persists_tags_relationships_and_media_refs(tmp_path, monkeypatch) -> None:
+    app = await create_test_app(tmp_path, monkeypatch)
+    asset_id = uuid4()
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        page = await create_page(client, "ecology-report")
+        related_page = await create_page(client, "field-notes")
+        response = await client.put(
+            f"/pages/{page['page']['id']}/metadata",
+            json={
+                "expected_page_version": page["page"]["version"],
+                "tags": [" ecology ", "rare", "rare"],
+                "classifications": ["confidential", "tier-2", "tier-2"],
+                "related_page_ids": [related_page["page"]["id"]],
+                "media_asset_ids": [str(asset_id), str(asset_id)],
+            },
+        )
+
+    body = response.json()
+    assert response.status_code == 200
+    assert body["page"]["tags"] == ["ecology", "rare"]
+    assert body["page"]["classifications"] == ["confidential", "tier-2"]
+    assert body["page"]["related_page_ids"] == [related_page["page"]["id"]]
+    assert body["page"]["media_asset_ids"] == [str(asset_id)]
+    assert body["page"]["version"] == page["page"]["version"] + 1
+
+
+async def test_metadata_update_is_visible_in_page_state_reads(tmp_path, monkeypatch) -> None:
+    app = await create_test_app(tmp_path, monkeypatch)
+    asset_id = uuid4()
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        page = await create_page(client, "zone-map")
+        related_page = await create_page(client, "zone-addendum")
+        update_response = await client.put(
+            f"/pages/{page['page']['id']}/metadata",
+            json={
+                "expected_page_version": page["page"]["version"],
+                "tags": ["navigation"],
+                "classifications": ["public-release"],
+                "related_page_ids": [related_page["page"]["id"]],
+                "media_asset_ids": [str(asset_id)],
+            },
+        )
+        state_response = await client.get(f"/pages/{page['page']['id']}")
+
+    assert update_response.status_code == 200
+    state_body = state_response.json()
+    assert state_response.status_code == 200
+    assert state_body["page"]["tags"] == ["navigation"]
+    assert state_body["page"]["classifications"] == ["public-release"]
+    assert state_body["page"]["related_page_ids"] == [related_page["page"]["id"]]
+    assert state_body["page"]["media_asset_ids"] == [str(asset_id)]
+
+
+async def test_metadata_validation_rejects_self_references(tmp_path, monkeypatch) -> None:
+    app = await create_test_app(tmp_path, monkeypatch)
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        page = await create_page(client, "self-linked-page")
+        response = await client.put(
+            f"/pages/{page['page']['id']}/metadata",
+            json={
+                "expected_page_version": page["page"]["version"],
+                "tags": [],
+                "classifications": [],
+                "related_page_ids": [page["page"]["id"]],
+                "media_asset_ids": [],
+            },
+        )
+
+    assert response.status_code == 400
+    assert "cannot reference itself" in response.json()["detail"]

--- a/services/encyclopedia/tests/test_models.py
+++ b/services/encyclopedia/tests/test_models.py
@@ -1,0 +1,115 @@
+from sqlalchemy import inspect
+from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+from domain import PageStatus, PageType, Visibility
+from models import Base
+from repository import PageRepository, StalePageVersionError
+
+
+async def test_create_all_builds_page_and_revision_tables() -> None:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+
+    async with engine.begin() as connection:
+        await connection.run_sync(Base.metadata.create_all)
+        table_names = await connection.run_sync(
+            lambda sync_connection: inspect(sync_connection).get_table_names()
+        )
+
+    assert sorted(table_names) == ["pages", "revisions"]
+    await engine.dispose()
+
+
+async def test_revision_storage_preserves_lineage_and_distinct_page_pointers() -> None:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    session_maker = async_sessionmaker(engine, expire_on_commit=False)
+
+    async with engine.begin() as connection:
+        await connection.run_sync(Base.metadata.create_all)
+
+    async with session_maker() as session:
+        repository = PageRepository(session)
+        page = await repository.create_page(
+            slug="zone-anomaly",
+            page_type=PageType.ANOMALY,
+            visibility=Visibility.PUBLIC,
+        )
+        first_revision = await repository.create_revision(
+            page_id=page.id,
+            title="Zone Anomaly",
+            summary="First summary",
+            content="Initial body",
+        )
+        await repository.update_page_state(
+            page_id=page.id,
+            expected_version=page.version,
+            current_draft_revision_id=first_revision.id,
+            current_published_revision_id=first_revision.id,
+            status=PageStatus.PUBLISHED,
+        )
+
+        second_revision = await repository.create_revision(
+            page_id=page.id,
+            parent_revision_id=first_revision.id,
+            title="Zone Anomaly",
+            summary="Updated summary",
+            content="Draft body",
+        )
+        await repository.update_page_state(
+            page_id=page.id,
+            expected_version=page.version,
+            current_draft_revision_id=second_revision.id,
+            status=PageStatus.DRAFT,
+        )
+        await session.commit()
+
+        revisions = await repository.list_revisions(page.id)
+        lineage = await repository.get_revision_lineage(second_revision.id)
+        refreshed_page = await repository.get_page(page.id)
+
+    assert len(revisions) == 2
+    assert [revision.id for revision in lineage] == [second_revision.id, first_revision.id]
+    assert refreshed_page is not None
+    assert refreshed_page.current_published_revision_id == first_revision.id
+    assert refreshed_page.current_draft_revision_id == second_revision.id
+    assert refreshed_page.version == 3
+    await engine.dispose()
+
+
+async def test_page_state_updates_reject_stale_versions() -> None:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    session_maker = async_sessionmaker(engine, expire_on_commit=False)
+
+    async with engine.begin() as connection:
+        await connection.run_sync(Base.metadata.create_all)
+
+    async with session_maker() as session:
+        repository = PageRepository(session)
+        page = await repository.create_page(
+            slug="artifact-record",
+            page_type=PageType.ARTIFACT,
+            visibility=Visibility.INTERNAL,
+        )
+        revision = await repository.create_revision(
+            page_id=page.id,
+            title="Artifact Record",
+            summary="Seed revision",
+            content="Body",
+        )
+        await repository.update_page_state(
+            page_id=page.id,
+            expected_version=page.version,
+            current_draft_revision_id=revision.id,
+        )
+
+        try:
+            await repository.update_page_state(
+                page_id=page.id,
+                expected_version=1,
+                current_published_revision_id=revision.id,
+            )
+        except StalePageVersionError:
+            pass
+        else:
+            raise AssertionError("Expected stale page version to be rejected.")
+
+    await engine.dispose()

--- a/services/encyclopedia/tests/test_models.py
+++ b/services/encyclopedia/tests/test_models.py
@@ -15,7 +15,12 @@ async def test_create_all_builds_page_and_revision_tables() -> None:
             lambda sync_connection: inspect(sync_connection).get_table_names()
         )
 
-    assert sorted(table_names) == ["pages", "revisions"]
+    assert sorted(table_names) == [
+        "page_media_references",
+        "page_relationships",
+        "pages",
+        "revisions",
+    ]
     await engine.dispose()
 
 

--- a/services/encyclopedia/tests/test_read_flow.py
+++ b/services/encyclopedia/tests/test_read_flow.py
@@ -1,0 +1,102 @@
+from pathlib import Path
+
+from httpx import ASGITransport, AsyncClient
+
+from config import get_settings
+from db import get_engine, reset_database_state
+from main import create_app
+from models import Base
+
+
+async def create_test_app(tmp_path: Path, monkeypatch) -> object:
+    database_path = tmp_path / "encyclopedia-read-test.db"
+    monkeypatch.setenv(
+        "ENCYCLOPEDIA_SERVICE_DATABASE_URL",
+        f"sqlite+aiosqlite:///{database_path}",
+    )
+    get_settings.cache_clear()
+    reset_database_state()
+
+    app = create_app()
+    async with get_engine().begin() as connection:
+        await connection.run_sync(Base.metadata.create_all)
+    return app
+
+
+async def seed_page_with_two_revisions(client: AsyncClient) -> tuple[dict, dict]:
+    create_response = await client.post(
+        "/pages",
+        json={
+            "slug": "controller-anomaly",
+            "type": "Anomaly",
+            "visibility": "Public",
+            "title": "Controller",
+            "summary": "Initial summary.",
+            "content": "Initial content.",
+        },
+    )
+    create_body = create_response.json()
+    edit_response = await client.post(
+        f"/pages/{create_body['page']['id']}/drafts",
+        json={
+            "expected_page_version": create_body["page"]["version"],
+            "title": "Controller",
+            "summary": "Updated summary.",
+            "content": "Updated content.",
+        },
+    )
+    return create_body, edit_response.json()
+
+
+async def test_get_page_state_returns_current_draft_and_page_metadata(tmp_path, monkeypatch) -> None:
+    app = await create_test_app(tmp_path, monkeypatch)
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        create_body, edit_body = await seed_page_with_two_revisions(client)
+        response = await client.get(f"/pages/{create_body['page']['id']}")
+
+    body = response.json()
+    assert response.status_code == 200
+    assert body["page"]["id"] == create_body["page"]["id"]
+    assert body["page"]["current_draft_revision_id"] == edit_body["revision"]["id"]
+    assert body["current_draft_revision"]["id"] == edit_body["revision"]["id"]
+    assert body["current_published_revision"] is None
+
+
+async def test_list_page_revisions_returns_full_history(tmp_path, monkeypatch) -> None:
+    app = await create_test_app(tmp_path, monkeypatch)
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        create_body, edit_body = await seed_page_with_two_revisions(client)
+        response = await client.get(f"/pages/{create_body['page']['id']}/revisions")
+
+    body = response.json()
+    assert response.status_code == 200
+    assert [revision["id"] for revision in body["revisions"]] == [
+        create_body["revision"]["id"],
+        edit_body["revision"]["id"],
+    ]
+
+
+async def test_get_specific_revision_returns_lineage(tmp_path, monkeypatch) -> None:
+    app = await create_test_app(tmp_path, monkeypatch)
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        create_body, edit_body = await seed_page_with_two_revisions(client)
+        response = await client.get(
+            f"/pages/{create_body['page']['id']}/revisions/{edit_body['revision']['id']}"
+        )
+
+    body = response.json()
+    assert response.status_code == 200
+    assert body["revision"]["id"] == edit_body["revision"]["id"]
+    assert [revision["id"] for revision in body["lineage"]] == [
+        edit_body["revision"]["id"],
+        create_body["revision"]["id"],
+    ]

--- a/services/encyclopedia/tests/test_write_flow.py
+++ b/services/encyclopedia/tests/test_write_flow.py
@@ -1,0 +1,133 @@
+from pathlib import Path
+
+from httpx import ASGITransport, AsyncClient
+
+from config import get_settings
+from db import get_engine, reset_database_state
+from main import create_app
+from models import Base
+
+
+async def create_test_app(tmp_path: Path, monkeypatch) -> object:
+    database_path = tmp_path / "encyclopedia-test.db"
+    monkeypatch.setenv(
+        "ENCYCLOPEDIA_SERVICE_DATABASE_URL",
+        f"sqlite+aiosqlite:///{database_path}",
+    )
+    get_settings.cache_clear()
+    reset_database_state()
+
+    app = create_app()
+    async with get_engine().begin() as connection:
+        await connection.run_sync(Base.metadata.create_all)
+    return app
+
+
+async def test_create_page_creates_initial_draft_revision(tmp_path, monkeypatch) -> None:
+    app = await create_test_app(tmp_path, monkeypatch)
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        response = await client.post(
+            "/pages",
+            json={
+                "slug": "burner-anomaly",
+                "type": "Anomaly",
+                "visibility": "Public",
+                "title": "Burner",
+                "summary": "Localized thermal distortion.",
+                "content": "Initial draft body.",
+            },
+        )
+
+    body = response.json()
+    assert response.status_code == 201
+    assert body["page"]["slug"] == "burner-anomaly"
+    assert body["page"]["status"] == "Draft"
+    assert body["page"]["current_published_revision_id"] is None
+    assert body["page"]["current_draft_revision_id"] == body["revision"]["id"]
+    assert body["page"]["version"] == 2
+    assert body["revision"]["parent_revision_id"] is None
+
+
+async def test_draft_edit_creates_new_revision_and_preserves_previous_revision(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    app = await create_test_app(tmp_path, monkeypatch)
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        create_response = await client.post(
+            "/pages",
+            json={
+                "slug": "whirligig-anomaly",
+                "type": "Anomaly",
+                "visibility": "Public",
+                "title": "Whirligig",
+                "summary": "Initial summary.",
+                "content": "Initial content.",
+            },
+        )
+        create_body = create_response.json()
+        edit_response = await client.post(
+            f"/pages/{create_body['page']['id']}/drafts",
+            json={
+                "expected_page_version": create_body["page"]["version"],
+                "title": "Whirligig",
+                "summary": "Updated summary.",
+                "content": "Updated content.",
+            },
+        )
+
+    edit_body = edit_response.json()
+    assert edit_response.status_code == 201
+    assert edit_body["page"]["current_draft_revision_id"] == edit_body["revision"]["id"]
+    assert edit_body["page"]["version"] == 3
+    assert edit_body["revision"]["parent_revision_id"] == create_body["revision"]["id"]
+    assert edit_body["revision"]["id"] != create_body["revision"]["id"]
+
+
+async def test_stale_draft_edit_returns_conflict(tmp_path, monkeypatch) -> None:
+    app = await create_test_app(tmp_path, monkeypatch)
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test",
+    ) as client:
+        create_response = await client.post(
+            "/pages",
+            json={
+                "slug": "electro-anomaly",
+                "type": "Anomaly",
+                "visibility": "Internal",
+                "title": "Electro",
+                "summary": "Initial summary.",
+                "content": "Initial content.",
+            },
+        )
+        create_body = create_response.json()
+
+        first_edit = await client.post(
+            f"/pages/{create_body['page']['id']}/drafts",
+            json={
+                "expected_page_version": create_body["page"]["version"],
+                "title": "Electro",
+                "summary": "Updated summary.",
+                "content": "Updated content.",
+            },
+        )
+        stale_edit = await client.post(
+            f"/pages/{create_body['page']['id']}/drafts",
+            json={
+                "expected_page_version": create_body["page"]["version"],
+                "title": "Electro",
+                "summary": "Stale summary.",
+                "content": "Stale content.",
+            },
+        )
+
+    assert first_edit.status_code == 201
+    assert stale_edit.status_code == 409
+    assert "Expected page version" in stale_edit.json()["detail"]


### PR DESCRIPTION
## Summary
Implement the first real  delivery for issues #24, #25, #26, #27, #28, #29, and #31.

This PR replaces the encyclopedia placeholder with a real FastAPI service and adds:
- runtime wiring, health/readiness, Dockerfile, requirements, and compose/bootstrap integration
- persistent page and immutable revision storage with draft and published revision pointers
- optimistic page version checks to reject stale concurrent draft edits
- create/edit draft flows, revision history reads, and point-in-time revision lookup with lineage
- publish, revert, and explicit lifecycle transitions for , , , , and 
- canonical metadata, related page links, and media asset references
- dedicated encyclopedia tests and a standalone GitHub Actions workflow

## Why
Issue #10 is the core content-service epic, and the repository only had a one-line encyclopedia placeholder. That blocked the first canonical implementation of page history, publication state, metadata ownership, and the gateway integration work that depends on a real downstream encyclopedia service.

## Scope
Included:
-  scaffold FastAPI service and persistence wiring
-  define immutable page and revision storage model
-  implement revision creation and draft editing flow
-  implement revision history and point-in-time read APIs
-  implement publish, revert, and lifecycle transitions
-  add canonical metadata, relationships, and media references
-  add tests and CI workflow

Not included:
-  domain event emission

That remains separate because event payload and delivery semantics should be reviewed independently and aligned with  work.

## Validation
Ran locally:
- ============================= test session starts ==============================
platform darwin -- Python 3.11.15, pytest-9.0.3, pluggy-1.6.0
rootdir: /Users/ivansen/Documents/anomaly-wiki
plugins: asyncio-1.3.0, anyio-4.13.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
collected 0 items

============================ no tests ran in 0.00s =============================
- Result: 

Also checked:
- encyclopedia modules compile with 
- GitNexus change detection before each issue-scoped commit reported low-risk scope with no affected processes

## Risk
Medium.

Main considerations:
- revision and lifecycle behavior are now the source-of-truth contract for downstream gateway and indexing work, so later changes here need careful compatibility review
- metadata support is canonical at the encyclopedia layer, but media ownership is still external and only asset references are stored here
- this PR creates tables directly at startup for now; if the project later adopts migrations, that will need a follow-up transition

## Compatibility
- compose now includes  and provisions 
- no gateway route integration is included in this PR
- shared event emission is not included yet

## Notes
This branch is based on the open gateway branch/PR  and should be rebased onto  after  merges.