### PR TITLE
Search index service

### DIFF
--- a/.github/workflows/search-indexer-tests.yml
+++ b/.github/workflows/search-indexer-tests.yml
@@ -1,0 +1,37 @@
+name: Search Indexer Tests
+
+on:
+  push:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  search-indexer-tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12"]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: services/search-indexer/requirements.txt
+
+      - name: Install search-indexer dependencies
+        working-directory: services/search-indexer
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -r requirements.txt
+
+      - name: Run search-indexer tests
+        working-directory: services/search-indexer
+        run: python -m pytest

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,6 @@
 *.pyc
+venv/
+.env
+__pycache__/
+*.egg-info/
+.pytest_cache/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -105,10 +105,13 @@ services:
     depends_on:
       db:
         condition: service_healthy
+      rabbitmq:
+        condition: service_healthy
     environment:
       ENCYCLOPEDIA_SERVICE_DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER:-admin}:${POSTGRES_PASSWORD:-admin}@db:5432/encyclopedia_db
-    expose:
-      - "8000"
+      ENCYCLOPEDIA_SERVICE_RABBITMQ_URL: amqp://${RABBITMQ_DEFAULT_USER:-guest}:${RABBITMQ_DEFAULT_PASS:-guest}@rabbitmq:5672/
+    ports:
+      - "8001:8000"
 
   media-service:
     build:
@@ -152,6 +155,29 @@ services:
       interval: 10s
       timeout: 5s
       retries: 5
+
+  search-indexer:
+    build:
+      context: .
+      dockerfile: services/search-indexer/Dockerfile
+    depends_on:
+      rabbitmq:
+        condition: service_healthy
+      opensearch:
+        condition: service_healthy
+      encyclopedia-service:
+        condition: service_started
+    environment:
+      SEARCH_INDEXER_RABBITMQ_URL: amqp://${RABBITMQ_DEFAULT_USER:-guest}:${RABBITMQ_DEFAULT_PASS:-guest}@rabbitmq:5672/
+      SEARCH_INDEXER_OPENSEARCH_URL: http://opensearch:9200
+      SEARCH_INDEXER_OPENSEARCH_INDEX: anomaly-wiki-pages
+      SEARCH_INDEXER_ENCYCLOPEDIA_URL: http://encyclopedia-service:8000
+    deploy:
+      resources:
+        limits:
+          cpus: '0.25'
+          memory: 128M
+    restart: on-failure
 
   api-gateway:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -110,8 +110,8 @@ services:
     environment:
       ENCYCLOPEDIA_SERVICE_DATABASE_URL: postgresql+asyncpg://${POSTGRES_USER:-admin}:${POSTGRES_PASSWORD:-admin}@db:5432/encyclopedia_db
       ENCYCLOPEDIA_SERVICE_RABBITMQ_URL: amqp://${RABBITMQ_DEFAULT_USER:-guest}:${RABBITMQ_DEFAULT_PASS:-guest}@rabbitmq:5672/
-    ports:
-      - "8001:8000"
+    expose:
+      - "8000"
 
   media-service:
     build:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -142,7 +142,7 @@ services:
     environment:
       SEARCH_SERVICE_OPENSEARCH_URL: http://opensearch:9200
       SEARCH_SERVICE_OPENSEARCH_INDEX: anomaly-wiki-pages
-      SEARCH_SERVICE_INTERNAL_TOKEN: ${INTERNAL_TOKEN:-}
+      SEARCH_SERVICE_INTERNAL_TOKEN: ${INTERNAL_TOKEN:?INTERNAL_TOKEN must be set}
     expose:
       - "8000"
     deploy:
@@ -167,6 +167,8 @@ services:
         condition: service_healthy
       encyclopedia-service:
         condition: service_started
+      search-service:
+        condition: service_healthy
     environment:
       SEARCH_INDEXER_RABBITMQ_URL: amqp://${RABBITMQ_DEFAULT_USER:-guest}:${RABBITMQ_DEFAULT_PASS:-guest}@rabbitmq:5672/
       SEARCH_INDEXER_OPENSEARCH_URL: http://opensearch:9200
@@ -197,7 +199,7 @@ services:
       API_GATEWAY_ENCYCLOPEDIA_BASE_URL: http://encyclopedia-service:8000
       API_GATEWAY_MEDIA_SERVICE_BASE_URL: http://media-service:8000
       API_GATEWAY_SEARCH_SERVICE_BASE_URL: http://search-service:8000
-      API_GATEWAY_SEARCH_INTERNAL_TOKEN: ${INTERNAL_TOKEN:-}
+      API_GATEWAY_SEARCH_INTERNAL_TOKEN: ${INTERNAL_TOKEN:?INTERNAL_TOKEN must be set}
     ports:
       - "8000:8000"
 

--- a/services/encyclopedia/config.py
+++ b/services/encyclopedia/config.py
@@ -1,4 +1,5 @@
 from functools import lru_cache
+from typing import Optional
 
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
@@ -7,6 +8,7 @@ class Settings(BaseSettings):
     encyclopedia_service_host: str = "0.0.0.0"
     encyclopedia_service_port: int = 8000
     database_url: str = "postgresql+asyncpg://admin:admin@db:5432/encyclopedia_db"
+    rabbitmq_url: Optional[str] = None
 
     model_config = SettingsConfigDict(
         env_prefix="ENCYCLOPEDIA_SERVICE_",

--- a/services/encyclopedia/main.py
+++ b/services/encyclopedia/main.py
@@ -2,8 +2,10 @@ from contextlib import asynccontextmanager
 
 from fastapi import FastAPI
 
+from config import get_settings
 from db import dispose_engine, get_engine
 from models import Base
+from publisher import NoopPublisher, connect_publisher
 from routes.health import router as health_router
 from routes.pages import router as pages_router
 
@@ -12,8 +14,15 @@ from routes.pages import router as pages_router
 async def lifespan(app: FastAPI):
     async with get_engine().begin() as connection:
         await connection.run_sync(Base.metadata.create_all)
-    yield
-    await dispose_engine()
+    settings = get_settings()
+    rabbitmq_connection, publisher = await connect_publisher(settings.rabbitmq_url)
+    app.state.publisher = publisher
+    try:
+        yield
+    finally:
+        if rabbitmq_connection:
+            await rabbitmq_connection.close()
+        await dispose_engine()
 
 
 def create_app() -> FastAPI:
@@ -23,6 +32,7 @@ def create_app() -> FastAPI:
         version="0.1.0",
         lifespan=lifespan,
     )
+    app.state.publisher = NoopPublisher()
     app.include_router(health_router)
     app.include_router(pages_router)
     return app

--- a/services/encyclopedia/publisher.py
+++ b/services/encyclopedia/publisher.py
@@ -1,0 +1,42 @@
+import json
+import logging
+from typing import Optional
+
+import aio_pika
+from aio_pika import ExchangeType, Message, DeliveryMode
+
+logger = logging.getLogger(__name__)
+
+EXCHANGE_NAME = "encyclopedia.events"
+
+
+class EventPublisher:
+    def __init__(self, exchange: aio_pika.Exchange) -> None:
+        self._exchange = exchange
+
+    async def publish(self, routing_key: str, body: dict) -> None:
+        message = Message(
+            body=json.dumps(body, default=str).encode(),
+            content_type="application/json",
+            delivery_mode=DeliveryMode.PERSISTENT,
+        )
+        await self._exchange.publish(message, routing_key=routing_key)
+        logger.debug("Published %s", routing_key)
+
+
+class NoopPublisher:
+    async def publish(self, routing_key: str, body: dict) -> None:
+        logger.debug("Noop publish: %s", routing_key)
+
+
+async def connect_publisher(
+    rabbitmq_url: Optional[str],
+) -> tuple[Optional[aio_pika.RobustConnection], "EventPublisher | NoopPublisher"]:
+    if not rabbitmq_url:
+        return None, NoopPublisher()
+    connection = await aio_pika.connect_robust(rabbitmq_url)
+    channel = await connection.channel()
+    exchange = await channel.declare_exchange(
+        EXCHANGE_NAME, ExchangeType.TOPIC, durable=True
+    )
+    return connection, EventPublisher(exchange)

--- a/services/encyclopedia/requirements.txt
+++ b/services/encyclopedia/requirements.txt
@@ -8,3 +8,4 @@ httpx==0.27.0
 pytest==9.0.3
 pytest-asyncio==1.3.0
 uvicorn[standard]==0.30.1
+aio-pika==9.4.3

--- a/services/encyclopedia/routes/pages.py
+++ b/services/encyclopedia/routes/pages.py
@@ -1,6 +1,6 @@
 from uuid import UUID
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from fastapi import APIRouter, Depends, HTTPException, Request, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from db import get_async_session
@@ -29,17 +29,24 @@ from schemas import (
 router = APIRouter(prefix="/pages", tags=["pages"])
 
 
+def _get_publisher(request: Request):
+    return request.app.state.publisher
+
+
 @router.post("", response_model=PageDraftResponse, status_code=status.HTTP_201_CREATED)
 async def create_page(
+    request: Request,
     payload: CreatePageRequest,
     session: AsyncSession = Depends(get_async_session),
 ) -> PageDraftResponse:
+    publisher = _get_publisher(request)
     service = PageService(session)
     try:
         page, revision = await service.create_page(payload)
     except PageAlreadyExistsError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
 
+    await publisher.publish("page.created", {"page_id": str(page.id), "slug": page.slug})
     return PageDraftResponse(page=page, revision=revision)
 
 
@@ -50,9 +57,11 @@ async def create_page(
 )
 async def create_draft_revision(
     page_id: UUID,
+    request: Request,
     payload: CreateDraftRevisionRequest,
     session: AsyncSession = Depends(get_async_session),
 ) -> PageDraftResponse:
+    publisher = _get_publisher(request)
     service = PageService(session)
     try:
         page, revision = await service.create_draft_revision(page_id=page_id, payload=payload)
@@ -63,6 +72,10 @@ async def create_draft_revision(
     except StalePageVersionError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
 
+    await publisher.publish(
+        "page.revision_created",
+        {"page_id": str(page.id), "revision_id": str(revision.id)},
+    )
     return PageDraftResponse(page=page, revision=revision)
 
 
@@ -152,9 +165,11 @@ async def get_page_revision(
 @router.post("/{page_id}/publish", response_model=PageStateResponse)
 async def publish_revision(
     page_id: UUID,
+    request: Request,
     payload: PublishRevisionRequest,
     session: AsyncSession = Depends(get_async_session),
 ) -> PageStateResponse:
+    publisher = _get_publisher(request)
     service = PageService(session)
     try:
         page, current_draft_revision, current_published_revision = await service.publish_revision(
@@ -166,6 +181,13 @@ async def publish_revision(
     except StalePageVersionError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
 
+    await publisher.publish(
+        "page.published",
+        {
+            "page_id": str(page.id),
+            "revision_id": str(current_published_revision.id) if current_published_revision else None,
+        },
+    )
     return PageStateResponse(
         page=page,
         current_draft_revision=current_draft_revision,
@@ -193,9 +215,11 @@ async def revert_revision(
 @router.post("/{page_id}/status", response_model=PageStateResponse)
 async def transition_page_status(
     page_id: UUID,
+    request: Request,
     payload: TransitionPageStatusRequest,
     session: AsyncSession = Depends(get_async_session),
 ) -> PageStateResponse:
+    publisher = _get_publisher(request)
     service = PageService(session)
     try:
         page, current_draft_revision, current_published_revision = await service.transition_page_status(
@@ -209,6 +233,13 @@ async def transition_page_status(
     except StalePageVersionError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
 
+    await publisher.publish(
+        "page.status_changed",
+        {
+            "page_id": str(page.id),
+            "new_status": page.status.value,
+        },
+    )
     return PageStateResponse(
         page=page,
         current_draft_revision=current_draft_revision,

--- a/services/encyclopedia/routes/pages.py
+++ b/services/encyclopedia/routes/pages.py
@@ -1,3 +1,4 @@
+import logging
 from uuid import UUID
 
 from fastapi import APIRouter, Depends, HTTPException, Request, status
@@ -26,6 +27,8 @@ from schemas import (
     UpdatePageMetadataRequest,
 )
 
+logger = logging.getLogger(__name__)
+
 router = APIRouter(prefix="/pages", tags=["pages"])
 
 
@@ -46,7 +49,10 @@ async def create_page(
     except PageAlreadyExistsError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
 
-    await publisher.publish("page.created", {"page_id": str(page.id), "slug": page.slug})
+    try:
+        await publisher.publish("page.created", {"page_id": str(page.id), "slug": page.slug})
+    except Exception as exc:
+        logger.warning("Failed to publish page.created for page %s: %s", page.id, exc)
     return PageDraftResponse(page=page, revision=revision)
 
 
@@ -72,10 +78,13 @@ async def create_draft_revision(
     except StalePageVersionError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
 
-    await publisher.publish(
-        "page.revision_created",
-        {"page_id": str(page.id), "revision_id": str(revision.id)},
-    )
+    try:
+        await publisher.publish(
+            "page.revision_created",
+            {"page_id": str(page.id), "revision_id": str(revision.id)},
+        )
+    except Exception as exc:
+        logger.warning("Failed to publish page.revision_created for page %s: %s", page.id, exc)
     return PageDraftResponse(page=page, revision=revision)
 
 
@@ -100,9 +109,11 @@ async def get_page_state(
 @router.put("/{page_id}/metadata", response_model=PageStateResponse)
 async def update_page_metadata(
     page_id: UUID,
+    request: Request,
     payload: UpdatePageMetadataRequest,
     session: AsyncSession = Depends(get_async_session),
 ) -> PageStateResponse:
+    publisher = _get_publisher(request)
     service = PageService(session)
     try:
         page, current_draft_revision, current_published_revision = await service.update_page_metadata(
@@ -120,6 +131,13 @@ async def update_page_metadata(
     except StalePageVersionError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
 
+    try:
+        await publisher.publish(
+            "page.metadata_updated",
+            {"page_id": str(page.id)},
+        )
+    except Exception as exc:
+        logger.warning("Failed to publish page.metadata_updated for page %s: %s", page.id, exc)
     return PageStateResponse(
         page=page,
         current_draft_revision=current_draft_revision,
@@ -181,13 +199,16 @@ async def publish_revision(
     except StalePageVersionError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
 
-    await publisher.publish(
-        "page.published",
-        {
-            "page_id": str(page.id),
-            "revision_id": str(current_published_revision.id) if current_published_revision else None,
-        },
-    )
+    try:
+        await publisher.publish(
+            "page.published",
+            {
+                "page_id": str(page.id),
+                "revision_id": str(current_published_revision.id) if current_published_revision else None,
+            },
+        )
+    except Exception as exc:
+        logger.warning("Failed to publish page.published for page %s: %s", page.id, exc)
     return PageStateResponse(
         page=page,
         current_draft_revision=current_draft_revision,
@@ -233,13 +254,16 @@ async def transition_page_status(
     except StalePageVersionError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
 
-    await publisher.publish(
-        "page.status_changed",
-        {
-            "page_id": str(page.id),
-            "new_status": page.status.value,
-        },
-    )
+    try:
+        await publisher.publish(
+            "page.status_changed",
+            {
+                "page_id": str(page.id),
+                "new_status": page.status.value,
+            },
+        )
+    except Exception as exc:
+        logger.warning("Failed to publish page.status_changed for page %s: %s", page.id, exc)
     return PageStateResponse(
         page=page,
         current_draft_revision=current_draft_revision,

--- a/services/encyclopedia/tests/test_event_publishing.py
+++ b/services/encyclopedia/tests/test_event_publishing.py
@@ -110,3 +110,59 @@ async def test_transition_status_publishes_status_changed_event(tmp_path, monkey
     body = call_args.args[1]
     assert body["page_id"] == page_id
     assert body["new_status"] == "Review"
+
+
+async def test_create_page_succeeds_even_when_publisher_raises(tmp_path, monkeypatch):
+    app, mock_publisher = await create_test_app_with_mock_publisher(tmp_path, monkeypatch)
+    mock_publisher.publish.side_effect = Exception("RabbitMQ unavailable")
+
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        response = await client.post(
+            "/pages",
+            json={
+                "slug": "resilient-page",
+                "type": "Anomaly",
+                "visibility": "Public",
+                "title": "Resilient Page",
+                "summary": "Should not fail.",
+                "content": "Even if MQ is down.",
+            },
+        )
+
+    assert response.status_code == 201
+
+
+async def test_update_metadata_publishes_metadata_updated_event(tmp_path, monkeypatch):
+    app, mock_publisher = await create_test_app_with_mock_publisher(tmp_path, monkeypatch)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        create_resp = await client.post(
+            "/pages",
+            json={
+                "slug": "meta-test",
+                "type": "Anomaly",
+                "visibility": "Public",
+                "title": "Meta Test",
+                "summary": "Testing metadata.",
+                "content": "Content.",
+            },
+        )
+        page_id = create_resp.json()["page"]["id"]
+        page_version = create_resp.json()["page"]["version"]
+
+        mock_publisher.reset_mock()
+
+        await client.put(
+            f"/pages/{page_id}/metadata",
+            json={
+                "expected_page_version": page_version,
+                "tags": ["new-tag"],
+                "classifications": [],
+                "related_page_ids": [],
+                "media_asset_ids": [],
+            },
+        )
+
+    mock_publisher.publish.assert_called_once()
+    call_args = mock_publisher.publish.call_args
+    assert call_args.args[0] == "page.metadata_updated"
+    assert call_args.args[1]["page_id"] == page_id

--- a/services/encyclopedia/tests/test_event_publishing.py
+++ b/services/encyclopedia/tests/test_event_publishing.py
@@ -1,0 +1,112 @@
+from pathlib import Path
+from unittest.mock import AsyncMock
+from httpx import ASGITransport, AsyncClient
+import pytest
+
+from config import get_settings
+from db import get_engine, reset_database_state
+from main import create_app
+from models import Base
+from publisher import NoopPublisher
+
+
+async def create_test_app_with_mock_publisher(tmp_path: Path, monkeypatch) -> tuple:
+    database_path = tmp_path / "enc-events-test.db"
+    monkeypatch.setenv(
+        "ENCYCLOPEDIA_SERVICE_DATABASE_URL",
+        f"sqlite+aiosqlite:///{database_path}",
+    )
+    get_settings.cache_clear()
+    reset_database_state()
+
+    app = create_app()
+    mock_publisher = AsyncMock(spec=NoopPublisher)
+    app.state.publisher = mock_publisher
+
+    async with get_engine().begin() as connection:
+        await connection.run_sync(Base.metadata.create_all)
+    return app, mock_publisher
+
+
+async def test_create_page_publishes_page_created_event(tmp_path, monkeypatch):
+    app, mock_publisher = await create_test_app_with_mock_publisher(tmp_path, monkeypatch)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        await client.post(
+            "/pages",
+            json={
+                "slug": "burner",
+                "type": "Anomaly",
+                "visibility": "Public",
+                "title": "Burner Anomaly",
+                "summary": "Hot.",
+                "content": "It burns.",
+            },
+        )
+
+    mock_publisher.publish.assert_called_once()
+    call_args = mock_publisher.publish.call_args
+    assert call_args.args[0] == "page.created"
+    assert "page_id" in call_args.args[1]
+
+
+async def test_publish_revision_publishes_page_published_event(tmp_path, monkeypatch):
+    app, mock_publisher = await create_test_app_with_mock_publisher(tmp_path, monkeypatch)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        create_resp = await client.post(
+            "/pages",
+            json={
+                "slug": "flash",
+                "type": "Anomaly",
+                "visibility": "Public",
+                "title": "Flash",
+                "summary": "Bright.",
+                "content": "Flash anomaly.",
+            },
+        )
+        page_id = create_resp.json()["page"]["id"]
+        revision_id = create_resp.json()["revision"]["id"]
+        page_version = create_resp.json()["page"]["version"]
+
+        mock_publisher.reset_mock()
+
+        await client.post(
+            f"/pages/{page_id}/publish",
+            json={"expected_page_version": page_version, "revision_id": revision_id},
+        )
+
+    mock_publisher.publish.assert_called_once()
+    call_args = mock_publisher.publish.call_args
+    assert call_args.args[0] == "page.published"
+    assert call_args.args[1]["page_id"] == page_id
+
+
+async def test_transition_status_publishes_status_changed_event(tmp_path, monkeypatch):
+    app, mock_publisher = await create_test_app_with_mock_publisher(tmp_path, monkeypatch)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        create_resp = await client.post(
+            "/pages",
+            json={
+                "slug": "psi-storm",
+                "type": "Anomaly",
+                "visibility": "Internal",
+                "title": "Psi Storm",
+                "summary": "Mental hazard.",
+                "content": "Dangerous.",
+            },
+        )
+        page_id = create_resp.json()["page"]["id"]
+        page_version = create_resp.json()["page"]["version"]
+
+        mock_publisher.reset_mock()
+
+        await client.post(
+            f"/pages/{page_id}/status",
+            json={"expected_page_version": page_version, "status": "Review"},
+        )
+
+    mock_publisher.publish.assert_called_once()
+    call_args = mock_publisher.publish.call_args
+    assert call_args.args[0] == "page.status_changed"
+    body = call_args.args[1]
+    assert body["page_id"] == page_id
+    assert body["new_status"] == "Review"

--- a/services/encyclopedia/tests/test_publisher.py
+++ b/services/encyclopedia/tests/test_publisher.py
@@ -1,0 +1,24 @@
+import json
+from unittest.mock import AsyncMock, MagicMock
+import pytest
+from publisher import EventPublisher, NoopPublisher
+
+
+async def test_event_publisher_publishes_json_message():
+    mock_exchange = AsyncMock()
+    publisher = EventPublisher(mock_exchange)
+
+    await publisher.publish("page.created", {"page_id": "abc-123", "slug": "test"})
+
+    mock_exchange.publish.assert_called_once()
+    call_args = mock_exchange.publish.call_args
+    message = call_args.args[0]
+    body = json.loads(message.body)
+    assert body["page_id"] == "abc-123"
+    routing_key = call_args.kwargs["routing_key"]
+    assert routing_key == "page.created"
+
+
+async def test_noop_publisher_does_not_raise():
+    publisher = NoopPublisher()
+    await publisher.publish("page.created", {"page_id": "abc-123"})

--- a/services/search-indexer/Dockerfile
+++ b/services/search-indexer/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.12-slim
+WORKDIR /app
+COPY services/search-indexer/requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+COPY services/search-indexer/ .
+CMD ["python", "main.py"]

--- a/services/search-indexer/config.py
+++ b/services/search-indexer/config.py
@@ -1,0 +1,22 @@
+from functools import lru_cache
+from typing import Optional
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class Settings(BaseSettings):
+    rabbitmq_url: str = "amqp://guest:guest@rabbitmq:5672/"
+    opensearch_url: str = "http://opensearch:9200"
+    opensearch_index: str = "anomaly-wiki-pages"
+    encyclopedia_url: str = "http://encyclopedia-service:8000"
+    exchange_name: str = "encyclopedia.events"
+    queue_name: str = "search-indexer"
+
+    model_config = SettingsConfigDict(
+        env_prefix="SEARCH_INDEXER_",
+        case_sensitive=False,
+    )
+
+
+@lru_cache
+def get_settings() -> Settings:
+    return Settings()

--- a/services/search-indexer/config.py
+++ b/services/search-indexer/config.py
@@ -1,5 +1,4 @@
 from functools import lru_cache
-from typing import Optional
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 

--- a/services/search-indexer/consumer.py
+++ b/services/search-indexer/consumer.py
@@ -1,4 +1,3 @@
-import asyncio
 import json
 import logging
 from typing import Any
@@ -7,6 +6,7 @@ from uuid import UUID
 import aio_pika
 from aio_pika import ExchangeType
 from opensearchpy import AsyncOpenSearch
+import httpx
 
 from config import Settings
 from encyclopedia_client import EncyclopediaClient
@@ -14,8 +14,7 @@ from indexer import delete_page, upsert_page
 
 logger = logging.getLogger(__name__)
 
-_UPSERT_ROUTING_KEYS = {"page.created", "page.revision_created", "page.published"}
-_DELETE_STATUSES = {"Archived", "Redacted"}
+_UPSERT_ROUTING_KEYS = {"page.created", "page.revision_created", "page.published", "page.metadata_updated"}
 
 
 async def _handle_message(
@@ -31,37 +30,34 @@ async def _handle_message(
     elif routing_key == "page.status_changed":
         page_id = UUID(body["page_id"])
         new_status = body["new_status"]
-        if new_status in _DELETE_STATUSES:
-            await delete_page(page_id, os_client, index)
-        elif new_status == "Published":
+        if new_status == "Published":
             await upsert_page(page_id, encyclopedia, os_client, index)
+        else:
+            await delete_page(page_id, os_client, index)
     else:
         logger.debug("Ignored routing key: %s", routing_key)
 
 
 async def run_consumer(settings: Settings) -> None:
-    import httpx
-
     os_client = AsyncOpenSearch(hosts=[settings.opensearch_url.rstrip("/")])
     http_client = httpx.AsyncClient(base_url=settings.encyclopedia_url)
     encyclopedia = EncyclopediaClient(http_client)
 
-    connection = await aio_pika.connect_robust(settings.rabbitmq_url)
-    async with connection:
-        channel = await connection.channel()
-        exchange = await channel.declare_exchange(
-            settings.exchange_name, ExchangeType.TOPIC, durable=True
-        )
-        queue = await channel.declare_queue(settings.queue_name, durable=True)
-        await queue.bind(exchange, routing_key="page.*")
-        await queue.bind(exchange, routing_key="media.*")
+    try:
+        connection = await aio_pika.connect_robust(settings.rabbitmq_url)
+        async with connection:
+            channel = await connection.channel()
+            exchange = await channel.declare_exchange(
+                settings.exchange_name, ExchangeType.TOPIC, durable=True
+            )
+            queue = await channel.declare_queue(settings.queue_name, durable=True)
+            await queue.bind(exchange, routing_key="page.*")
 
-        logger.info("Search indexer listening on queue '%s'", settings.queue_name)
+            logger.info("Search indexer listening on queue '%s'", settings.queue_name)
 
-        async with queue.iterator() as queue_iter:
-            async for message in queue_iter:
-                async with message.process():
-                    try:
+            async with queue.iterator() as queue_iter:
+                async for message in queue_iter:
+                    async with message.process(requeue=True):
                         body = json.loads(message.body)
                         await _handle_message(
                             routing_key=message.routing_key,
@@ -70,10 +66,6 @@ async def run_consumer(settings: Settings) -> None:
                             os_client=os_client,
                             index=settings.opensearch_index,
                         )
-                    except Exception as exc:
-                        logger.error(
-                            "Error handling %s: %s: %s",
-                            message.routing_key,
-                            type(exc).__name__,
-                            exc,
-                        )
+    finally:
+        await http_client.aclose()
+        await os_client.close()

--- a/services/search-indexer/consumer.py
+++ b/services/search-indexer/consumer.py
@@ -15,6 +15,7 @@ from indexer import delete_page, upsert_page
 logger = logging.getLogger(__name__)
 
 _UPSERT_ROUTING_KEYS = {"page.created", "page.revision_created", "page.published", "page.metadata_updated"}
+_TERMINAL_STATUSES = {"Archived", "Redacted"}
 
 
 async def _handle_message(
@@ -30,10 +31,10 @@ async def _handle_message(
     elif routing_key == "page.status_changed":
         page_id = UUID(body["page_id"])
         new_status = body["new_status"]
-        if new_status == "Published":
-            await upsert_page(page_id, encyclopedia, os_client, index)
-        else:
+        if new_status in _TERMINAL_STATUSES:
             await delete_page(page_id, os_client, index)
+        else:
+            await upsert_page(page_id, encyclopedia, os_client, index)
     else:
         logger.debug("Ignored routing key: %s", routing_key)
 
@@ -57,15 +58,29 @@ async def run_consumer(settings: Settings) -> None:
 
             async with queue.iterator() as queue_iter:
                 async for message in queue_iter:
-                    async with message.process(requeue=True):
+                    try:
                         body = json.loads(message.body)
-                        await _handle_message(
-                            routing_key=message.routing_key,
-                            body=body,
-                            encyclopedia=encyclopedia,
-                            os_client=os_client,
-                            index=settings.opensearch_index,
-                        )
+                    except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+                        logger.error("Malformed message body, rejecting: %s", exc)
+                        await message.reject(requeue=False)
+                        continue
+
+                    async with message.process(requeue=True, ignore_processed=True):
+                        try:
+                            await _handle_message(
+                                routing_key=message.routing_key,
+                                body=body,
+                                encyclopedia=encyclopedia,
+                                os_client=os_client,
+                                index=settings.opensearch_index,
+                            )
+                        except (KeyError, ValueError) as exc:
+                            logger.error(
+                                "Invalid message schema for routing key %s, rejecting: %s",
+                                message.routing_key,
+                                exc,
+                            )
+                            await message.reject(requeue=False)
     finally:
         await http_client.aclose()
         await os_client.close()

--- a/services/search-indexer/consumer.py
+++ b/services/search-indexer/consumer.py
@@ -1,0 +1,79 @@
+import asyncio
+import json
+import logging
+from typing import Any
+from uuid import UUID
+
+import aio_pika
+from aio_pika import ExchangeType
+from opensearchpy import AsyncOpenSearch
+
+from config import Settings
+from encyclopedia_client import EncyclopediaClient
+from indexer import delete_page, upsert_page
+
+logger = logging.getLogger(__name__)
+
+_UPSERT_ROUTING_KEYS = {"page.created", "page.revision_created", "page.published"}
+_DELETE_STATUSES = {"Archived", "Redacted"}
+
+
+async def _handle_message(
+    routing_key: str,
+    body: dict[str, Any],
+    encyclopedia: EncyclopediaClient,
+    os_client: AsyncOpenSearch,
+    index: str,
+) -> None:
+    if routing_key in _UPSERT_ROUTING_KEYS:
+        page_id = UUID(body["page_id"])
+        await upsert_page(page_id, encyclopedia, os_client, index)
+    elif routing_key == "page.status_changed":
+        page_id = UUID(body["page_id"])
+        new_status = body["new_status"]
+        if new_status in _DELETE_STATUSES:
+            await delete_page(page_id, os_client, index)
+        elif new_status == "Published":
+            await upsert_page(page_id, encyclopedia, os_client, index)
+    else:
+        logger.debug("Ignored routing key: %s", routing_key)
+
+
+async def run_consumer(settings: Settings) -> None:
+    import httpx
+
+    os_client = AsyncOpenSearch(hosts=[settings.opensearch_url.rstrip("/")])
+    http_client = httpx.AsyncClient(base_url=settings.encyclopedia_url)
+    encyclopedia = EncyclopediaClient(http_client)
+
+    connection = await aio_pika.connect_robust(settings.rabbitmq_url)
+    async with connection:
+        channel = await connection.channel()
+        exchange = await channel.declare_exchange(
+            settings.exchange_name, ExchangeType.TOPIC, durable=True
+        )
+        queue = await channel.declare_queue(settings.queue_name, durable=True)
+        await queue.bind(exchange, routing_key="page.*")
+        await queue.bind(exchange, routing_key="media.*")
+
+        logger.info("Search indexer listening on queue '%s'", settings.queue_name)
+
+        async with queue.iterator() as queue_iter:
+            async for message in queue_iter:
+                async with message.process():
+                    try:
+                        body = json.loads(message.body)
+                        await _handle_message(
+                            routing_key=message.routing_key,
+                            body=body,
+                            encyclopedia=encyclopedia,
+                            os_client=os_client,
+                            index=settings.opensearch_index,
+                        )
+                    except Exception as exc:
+                        logger.error(
+                            "Error handling %s: %s: %s",
+                            message.routing_key,
+                            type(exc).__name__,
+                            exc,
+                        )

--- a/services/search-indexer/encyclopedia_client.py
+++ b/services/search-indexer/encyclopedia_client.py
@@ -1,0 +1,33 @@
+from typing import Optional
+from uuid import UUID
+
+import httpx
+
+
+class PageState:
+    def __init__(
+        self,
+        page: dict,
+        current_published_revision: Optional[dict],
+        current_draft_revision: Optional[dict],
+    ) -> None:
+        self.page = page
+        self.current_published_revision = current_published_revision
+        self.current_draft_revision = current_draft_revision
+
+
+class EncyclopediaClient:
+    def __init__(self, http_client: httpx.AsyncClient) -> None:
+        self._client = http_client
+
+    async def get_page_state(self, page_id: UUID) -> Optional[PageState]:
+        response = await self._client.get(f"/pages/{page_id}")
+        if response.status_code == 404:
+            return None
+        response.raise_for_status()
+        data = response.json()
+        return PageState(
+            page=data["page"],
+            current_published_revision=data.get("current_published_revision"),
+            current_draft_revision=data.get("current_draft_revision"),
+        )

--- a/services/search-indexer/indexer.py
+++ b/services/search-indexer/indexer.py
@@ -1,0 +1,57 @@
+import logging
+from uuid import UUID
+
+from opensearchpy import AsyncOpenSearch
+
+from encyclopedia_client import EncyclopediaClient
+from markdown import extract_plain_text
+
+logger = logging.getLogger(__name__)
+
+
+def _build_document(page: dict, revision: dict) -> dict:
+    return {
+        "page_id": str(page["id"]),
+        "slug": page["slug"],
+        "type": page["type"],
+        "status": page["status"],
+        "visibility": page["visibility"],
+        "tags": page.get("tags", []),
+        "title": revision["title"],
+        "summary": revision.get("summary", ""),
+        "content_text": extract_plain_text(revision["content"]),
+        "aliases": [],
+    }
+
+
+async def upsert_page(
+    page_id: UUID,
+    encyclopedia: EncyclopediaClient,
+    os_client: AsyncOpenSearch,
+    index: str,
+) -> None:
+    state = await encyclopedia.get_page_state(page_id)
+    if state is None:
+        logger.warning("Page %s not found, skipping index", page_id)
+        return
+
+    revision = state.current_published_revision or state.current_draft_revision
+    if revision is None:
+        logger.info("Page %s has no revision yet, skipping index", page_id)
+        return
+
+    doc = _build_document(state.page, revision)
+    await os_client.index(index=index, id=str(page_id), body=doc)
+    logger.info("Indexed page %s (%s)", page_id, doc["slug"])
+
+
+async def delete_page(
+    page_id: UUID,
+    os_client: AsyncOpenSearch,
+    index: str,
+) -> None:
+    try:
+        await os_client.delete(index=index, id=str(page_id))
+        logger.info("Deleted page %s from index", page_id)
+    except Exception as exc:
+        logger.warning("Failed to delete page %s: %s", page_id, exc)

--- a/services/search-indexer/main.py
+++ b/services/search-indexer/main.py
@@ -1,7 +1,20 @@
-import time
+import asyncio
+import logging
 
-if __name__ == '__main__':
-    print('Search Indexer Placeholder started')
-    while True:
-        time.sleep(10)
+from config import get_settings
+from consumer import run_consumer
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s %(name)s %(message)s",
+)
+
+
+def main() -> None:
+    settings = get_settings()
+    asyncio.run(run_consumer(settings))
+
+
+if __name__ == "__main__":
+    main()
 

--- a/services/search-indexer/markdown.py
+++ b/services/search-indexer/markdown.py
@@ -1,0 +1,15 @@
+import re
+
+
+def extract_plain_text(markdown: str) -> str:
+    text = re.sub(r"```[\s\S]*?```", " ", markdown)
+    text = re.sub(r"`[^`\n]+`", " ", text)
+    text = re.sub(r"#{1,6}\s+", "", text)
+    text = re.sub(r"!\[([^\]]*)\]\([^\)]+\)", r"\1", text)
+    text = re.sub(r"\[([^\]]+)\]\([^\)]+\)", r"\1", text)
+    text = re.sub(r"\*{1,2}([^*\n]+)\*{1,2}", r"\1", text)
+    text = re.sub(r"_{1,2}([^_\n]+)_{1,2}", r"\1", text)
+    text = re.sub(r"^\s*[-*+]\s+", "", text, flags=re.MULTILINE)
+    text = re.sub(r"^\s*\d+\.\s+", "", text, flags=re.MULTILINE)
+    text = re.sub(r"\s+", " ", text)
+    return text.strip()

--- a/services/search-indexer/pytest.ini
+++ b/services/search-indexer/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+asyncio_mode = auto

--- a/services/search-indexer/requirements.txt
+++ b/services/search-indexer/requirements.txt
@@ -2,5 +2,5 @@ aio-pika==9.4.3
 opensearch-py[async]==2.4.2
 httpx==0.27.0
 pydantic-settings==2.3.4
-pytest==8.3.3
-pytest-asyncio==0.23.8
+pytest==9.0.3
+pytest-asyncio==1.3.0

--- a/services/search-indexer/requirements.txt
+++ b/services/search-indexer/requirements.txt
@@ -1,0 +1,6 @@
+aio-pika==9.4.3
+opensearch-py[async]==2.4.2
+httpx==0.27.0
+pydantic-settings==2.3.4
+pytest==8.3.3
+pytest-asyncio==0.23.8

--- a/services/search-indexer/tests/test_consumer.py
+++ b/services/search-indexer/tests/test_consumer.py
@@ -1,0 +1,120 @@
+from unittest.mock import AsyncMock
+from uuid import uuid4
+import pytest
+from consumer import _handle_message
+
+PAGE_ID = uuid4()
+REVISION_ID = uuid4()
+
+
+async def test_page_published_event_triggers_upsert():
+    enc = AsyncMock()
+    os = AsyncMock()
+    enc.get_page_state.return_value = None
+
+    await _handle_message(
+        routing_key="page.published",
+        body={"page_id": str(PAGE_ID), "revision_id": str(REVISION_ID)},
+        encyclopedia=enc,
+        os_client=os,
+        index="test-index",
+    )
+
+    enc.get_page_state.assert_called_once_with(PAGE_ID)
+
+
+async def test_page_created_event_triggers_upsert():
+    enc = AsyncMock()
+    os = AsyncMock()
+    enc.get_page_state.return_value = None
+
+    await _handle_message(
+        routing_key="page.created",
+        body={"page_id": str(PAGE_ID), "slug": "fire-anomaly"},
+        encyclopedia=enc,
+        os_client=os,
+        index="test-index",
+    )
+
+    enc.get_page_state.assert_called_once_with(PAGE_ID)
+
+
+async def test_page_revision_created_event_triggers_upsert():
+    enc = AsyncMock()
+    os = AsyncMock()
+    enc.get_page_state.return_value = None
+
+    await _handle_message(
+        routing_key="page.revision_created",
+        body={"page_id": str(PAGE_ID), "revision_id": str(REVISION_ID)},
+        encyclopedia=enc,
+        os_client=os,
+        index="test-index",
+    )
+
+    enc.get_page_state.assert_called_once_with(PAGE_ID)
+
+
+async def test_status_changed_to_archived_triggers_delete():
+    enc = AsyncMock()
+    os = AsyncMock()
+
+    await _handle_message(
+        routing_key="page.status_changed",
+        body={"page_id": str(PAGE_ID), "old_status": "Published", "new_status": "Archived"},
+        encyclopedia=enc,
+        os_client=os,
+        index="test-index",
+    )
+
+    os.delete.assert_called_once_with(index="test-index", id=str(PAGE_ID))
+    enc.get_page_state.assert_not_called()
+
+
+async def test_status_changed_to_redacted_triggers_delete():
+    enc = AsyncMock()
+    os = AsyncMock()
+
+    await _handle_message(
+        routing_key="page.status_changed",
+        body={"page_id": str(PAGE_ID), "old_status": "Published", "new_status": "Redacted"},
+        encyclopedia=enc,
+        os_client=os,
+        index="test-index",
+    )
+
+    os.delete.assert_called_once_with(index="test-index", id=str(PAGE_ID))
+
+
+async def test_status_changed_to_published_triggers_upsert():
+    enc = AsyncMock()
+    os = AsyncMock()
+    enc.get_page_state.return_value = None
+
+    await _handle_message(
+        routing_key="page.status_changed",
+        body={"page_id": str(PAGE_ID), "old_status": "Draft", "new_status": "Published"},
+        encyclopedia=enc,
+        os_client=os,
+        index="test-index",
+    )
+
+    enc.get_page_state.assert_called_once_with(PAGE_ID)
+    os.delete.assert_not_called()
+
+
+async def test_unknown_routing_key_is_noop():
+    enc = AsyncMock()
+    os = AsyncMock()
+
+    await _handle_message(
+        routing_key="media.metadata_updated",
+        body={"asset": {}},
+        encyclopedia=enc,
+        os_client=os,
+        index="test-index",
+    )
+
+    enc.get_page_state.assert_not_called()
+    os.index.assert_not_called()
+    os.delete.assert_not_called()

--- a/services/search-indexer/tests/test_consumer.py
+++ b/services/search-indexer/tests/test_consumer.py
@@ -1,120 +1,153 @@
-from unittest.mock import AsyncMock
+from unittest.mock import ANY, AsyncMock, patch
 from uuid import uuid4
-import pytest
-from consumer import _handle_message
 
-PAGE_ID = uuid4()
-REVISION_ID = uuid4()
+from consumer import _handle_message
 
 
 async def test_page_published_event_triggers_upsert():
-    enc = AsyncMock()
-    os = AsyncMock()
-    enc.get_page_state.return_value = None
-
-    await _handle_message(
-        routing_key="page.published",
-        body={"page_id": str(PAGE_ID), "revision_id": str(REVISION_ID)},
-        encyclopedia=enc,
-        os_client=os,
-        index="test-index",
-    )
-
-    enc.get_page_state.assert_called_once_with(PAGE_ID)
+    page_id = uuid4()
+    with patch("consumer.upsert_page", new_callable=AsyncMock) as mock_upsert, \
+         patch("consumer.delete_page", new_callable=AsyncMock) as mock_delete:
+        await _handle_message(
+            routing_key="page.published",
+            body={"page_id": str(page_id), "revision_id": str(uuid4())},
+            encyclopedia=AsyncMock(),
+            os_client=AsyncMock(),
+            index="test-index",
+        )
+        mock_upsert.assert_called_once_with(page_id, ANY, ANY, "test-index")
+        mock_delete.assert_not_called()
 
 
 async def test_page_created_event_triggers_upsert():
-    enc = AsyncMock()
-    os = AsyncMock()
-    enc.get_page_state.return_value = None
-
-    await _handle_message(
-        routing_key="page.created",
-        body={"page_id": str(PAGE_ID), "slug": "fire-anomaly"},
-        encyclopedia=enc,
-        os_client=os,
-        index="test-index",
-    )
-
-    enc.get_page_state.assert_called_once_with(PAGE_ID)
+    page_id = uuid4()
+    with patch("consumer.upsert_page", new_callable=AsyncMock) as mock_upsert, \
+         patch("consumer.delete_page", new_callable=AsyncMock) as mock_delete:
+        await _handle_message(
+            routing_key="page.created",
+            body={"page_id": str(page_id), "slug": "fire-anomaly"},
+            encyclopedia=AsyncMock(),
+            os_client=AsyncMock(),
+            index="test-index",
+        )
+        mock_upsert.assert_called_once_with(page_id, ANY, ANY, "test-index")
+        mock_delete.assert_not_called()
 
 
 async def test_page_revision_created_event_triggers_upsert():
-    enc = AsyncMock()
-    os = AsyncMock()
-    enc.get_page_state.return_value = None
-
-    await _handle_message(
-        routing_key="page.revision_created",
-        body={"page_id": str(PAGE_ID), "revision_id": str(REVISION_ID)},
-        encyclopedia=enc,
-        os_client=os,
-        index="test-index",
-    )
-
-    enc.get_page_state.assert_called_once_with(PAGE_ID)
+    page_id = uuid4()
+    with patch("consumer.upsert_page", new_callable=AsyncMock) as mock_upsert, \
+         patch("consumer.delete_page", new_callable=AsyncMock) as mock_delete:
+        await _handle_message(
+            routing_key="page.revision_created",
+            body={"page_id": str(page_id), "revision_id": str(uuid4())},
+            encyclopedia=AsyncMock(),
+            os_client=AsyncMock(),
+            index="test-index",
+        )
+        mock_upsert.assert_called_once_with(page_id, ANY, ANY, "test-index")
+        mock_delete.assert_not_called()
 
 
 async def test_status_changed_to_archived_triggers_delete():
-    enc = AsyncMock()
-    os = AsyncMock()
-
-    await _handle_message(
-        routing_key="page.status_changed",
-        body={"page_id": str(PAGE_ID), "old_status": "Published", "new_status": "Archived"},
-        encyclopedia=enc,
-        os_client=os,
-        index="test-index",
-    )
-
-    os.delete.assert_called_once_with(index="test-index", id=str(PAGE_ID))
-    enc.get_page_state.assert_not_called()
+    page_id = uuid4()
+    with patch("consumer.upsert_page", new_callable=AsyncMock) as mock_upsert, \
+         patch("consumer.delete_page", new_callable=AsyncMock) as mock_delete:
+        await _handle_message(
+            routing_key="page.status_changed",
+            body={"page_id": str(page_id), "old_status": "Published", "new_status": "Archived"},
+            encyclopedia=AsyncMock(),
+            os_client=AsyncMock(),
+            index="test-index",
+        )
+        mock_delete.assert_called_once_with(page_id, ANY, "test-index")
+        mock_upsert.assert_not_called()
 
 
 async def test_status_changed_to_redacted_triggers_delete():
-    enc = AsyncMock()
-    os = AsyncMock()
-
-    await _handle_message(
-        routing_key="page.status_changed",
-        body={"page_id": str(PAGE_ID), "old_status": "Published", "new_status": "Redacted"},
-        encyclopedia=enc,
-        os_client=os,
-        index="test-index",
-    )
-
-    os.delete.assert_called_once_with(index="test-index", id=str(PAGE_ID))
+    page_id = uuid4()
+    with patch("consumer.upsert_page", new_callable=AsyncMock) as mock_upsert, \
+         patch("consumer.delete_page", new_callable=AsyncMock) as mock_delete:
+        await _handle_message(
+            routing_key="page.status_changed",
+            body={"page_id": str(page_id), "old_status": "Published", "new_status": "Redacted"},
+            encyclopedia=AsyncMock(),
+            os_client=AsyncMock(),
+            index="test-index",
+        )
+        mock_delete.assert_called_once_with(page_id, ANY, "test-index")
+        mock_upsert.assert_not_called()
 
 
 async def test_status_changed_to_published_triggers_upsert():
-    enc = AsyncMock()
-    os = AsyncMock()
-    enc.get_page_state.return_value = None
-
-    await _handle_message(
-        routing_key="page.status_changed",
-        body={"page_id": str(PAGE_ID), "old_status": "Draft", "new_status": "Published"},
-        encyclopedia=enc,
-        os_client=os,
-        index="test-index",
-    )
-
-    enc.get_page_state.assert_called_once_with(PAGE_ID)
-    os.delete.assert_not_called()
+    page_id = uuid4()
+    with patch("consumer.upsert_page", new_callable=AsyncMock) as mock_upsert, \
+         patch("consumer.delete_page", new_callable=AsyncMock) as mock_delete:
+        await _handle_message(
+            routing_key="page.status_changed",
+            body={"page_id": str(page_id), "old_status": "Draft", "new_status": "Published"},
+            encyclopedia=AsyncMock(),
+            os_client=AsyncMock(),
+            index="test-index",
+        )
+        mock_upsert.assert_called_once_with(page_id, ANY, ANY, "test-index")
+        mock_delete.assert_not_called()
 
 
 async def test_unknown_routing_key_is_noop():
-    enc = AsyncMock()
-    os = AsyncMock()
+    with patch("consumer.upsert_page", new_callable=AsyncMock) as mock_upsert, \
+         patch("consumer.delete_page", new_callable=AsyncMock) as mock_delete:
+        await _handle_message(
+            routing_key="media.metadata_updated",
+            body={"asset": {}},
+            encyclopedia=AsyncMock(),
+            os_client=AsyncMock(),
+            index="test-index",
+        )
+        mock_upsert.assert_not_called()
+        mock_delete.assert_not_called()
 
-    await _handle_message(
-        routing_key="media.metadata_updated",
-        body={"asset": {}},
-        encyclopedia=enc,
-        os_client=os,
-        index="test-index",
-    )
 
-    enc.get_page_state.assert_not_called()
-    os.index.assert_not_called()
-    os.delete.assert_not_called()
+async def test_status_changed_to_draft_triggers_delete():
+    page_id = uuid4()
+    with patch("consumer.upsert_page", new_callable=AsyncMock) as mock_upsert, \
+         patch("consumer.delete_page", new_callable=AsyncMock) as mock_delete:
+        await _handle_message(
+            routing_key="page.status_changed",
+            body={"page_id": str(page_id), "old_status": "Published", "new_status": "Draft"},
+            encyclopedia=AsyncMock(),
+            os_client=AsyncMock(),
+            index="test-index",
+        )
+        mock_delete.assert_called_once_with(page_id, ANY, "test-index")
+        mock_upsert.assert_not_called()
+
+
+async def test_status_changed_to_review_triggers_delete():
+    page_id = uuid4()
+    with patch("consumer.upsert_page", new_callable=AsyncMock) as mock_upsert, \
+         patch("consumer.delete_page", new_callable=AsyncMock) as mock_delete:
+        await _handle_message(
+            routing_key="page.status_changed",
+            body={"page_id": str(page_id), "old_status": "Published", "new_status": "Review"},
+            encyclopedia=AsyncMock(),
+            os_client=AsyncMock(),
+            index="test-index",
+        )
+        mock_delete.assert_called_once_with(page_id, ANY, "test-index")
+        mock_upsert.assert_not_called()
+
+
+async def test_metadata_updated_event_triggers_upsert():
+    page_id = uuid4()
+    with patch("consumer.upsert_page", new_callable=AsyncMock) as mock_upsert, \
+         patch("consumer.delete_page", new_callable=AsyncMock) as mock_delete:
+        await _handle_message(
+            routing_key="page.metadata_updated",
+            body={"page_id": str(page_id)},
+            encyclopedia=AsyncMock(),
+            os_client=AsyncMock(),
+            index="test-index",
+        )
+        mock_upsert.assert_called_once_with(page_id, ANY, ANY, "test-index")
+        mock_delete.assert_not_called()

--- a/services/search-indexer/tests/test_consumer.py
+++ b/services/search-indexer/tests/test_consumer.py
@@ -108,7 +108,7 @@ async def test_unknown_routing_key_is_noop():
         mock_delete.assert_not_called()
 
 
-async def test_status_changed_to_draft_triggers_delete():
+async def test_status_changed_to_draft_triggers_upsert():
     page_id = uuid4()
     with patch("consumer.upsert_page", new_callable=AsyncMock) as mock_upsert, \
          patch("consumer.delete_page", new_callable=AsyncMock) as mock_delete:
@@ -119,11 +119,11 @@ async def test_status_changed_to_draft_triggers_delete():
             os_client=AsyncMock(),
             index="test-index",
         )
-        mock_delete.assert_called_once_with(page_id, ANY, "test-index")
-        mock_upsert.assert_not_called()
+        mock_upsert.assert_called_once_with(page_id, ANY, ANY, "test-index")
+        mock_delete.assert_not_called()
 
 
-async def test_status_changed_to_review_triggers_delete():
+async def test_status_changed_to_review_triggers_upsert():
     page_id = uuid4()
     with patch("consumer.upsert_page", new_callable=AsyncMock) as mock_upsert, \
          patch("consumer.delete_page", new_callable=AsyncMock) as mock_delete:
@@ -134,8 +134,8 @@ async def test_status_changed_to_review_triggers_delete():
             os_client=AsyncMock(),
             index="test-index",
         )
-        mock_delete.assert_called_once_with(page_id, ANY, "test-index")
-        mock_upsert.assert_not_called()
+        mock_upsert.assert_called_once_with(page_id, ANY, ANY, "test-index")
+        mock_delete.assert_not_called()
 
 
 async def test_metadata_updated_event_triggers_upsert():

--- a/services/search-indexer/tests/test_encyclopedia_client.py
+++ b/services/search-indexer/tests/test_encyclopedia_client.py
@@ -1,0 +1,63 @@
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+import pytest
+from encyclopedia_client import EncyclopediaClient, PageState
+
+PAGE_ID = uuid4()
+
+FULL_PAGE_RESPONSE = {
+    "page": {
+        "id": str(PAGE_ID),
+        "slug": "fire-anomaly",
+        "type": "Anomaly",
+        "status": "Published",
+        "visibility": "Public",
+        "tags": ["fire", "thermal"],
+        "classifications": [],
+    },
+    "current_published_revision": {
+        "id": str(uuid4()),
+        "page_id": str(PAGE_ID),
+        "title": "Fire Anomaly",
+        "summary": "A thermal anomaly near Agroprom.",
+        "content": "# Fire Anomaly\n\nVery hot.",
+    },
+    "current_draft_revision": None,
+}
+
+
+def _make_http_client(status_code: int, json_body: dict) -> AsyncMock:
+    response = MagicMock()
+    response.status_code = status_code
+    response.json.return_value = json_body
+    response.raise_for_status = MagicMock()
+    http_client = AsyncMock()
+    http_client.get.return_value = response
+    return http_client
+
+
+async def test_get_page_state_returns_state_on_200():
+    http_client = _make_http_client(200, FULL_PAGE_RESPONSE)
+    enc = EncyclopediaClient(http_client)
+    state = await enc.get_page_state(PAGE_ID)
+    assert isinstance(state, PageState)
+    assert state.page["slug"] == "fire-anomaly"
+    assert state.current_published_revision["title"] == "Fire Anomaly"
+    assert state.current_draft_revision is None
+
+
+async def test_get_page_state_returns_none_on_404():
+    response = MagicMock()
+    response.status_code = 404
+    http_client = AsyncMock()
+    http_client.get.return_value = response
+    enc = EncyclopediaClient(http_client)
+    state = await enc.get_page_state(PAGE_ID)
+    assert state is None
+
+
+async def test_get_page_state_calls_correct_url():
+    http_client = _make_http_client(200, FULL_PAGE_RESPONSE)
+    enc = EncyclopediaClient(http_client)
+    await enc.get_page_state(PAGE_ID)
+    http_client.get.assert_called_once_with(f"/pages/{PAGE_ID}")

--- a/services/search-indexer/tests/test_indexer.py
+++ b/services/search-indexer/tests/test_indexer.py
@@ -1,0 +1,125 @@
+from unittest.mock import AsyncMock
+from uuid import uuid4
+import pytest
+from encyclopedia_client import PageState
+from indexer import _build_document, upsert_page, delete_page
+
+PAGE_ID = uuid4()
+
+SAMPLE_PAGE = {
+    "id": str(PAGE_ID),
+    "slug": "fire-anomaly",
+    "type": "Anomaly",
+    "status": "Published",
+    "visibility": "Public",
+    "tags": ["fire", "thermal"],
+}
+
+SAMPLE_REVISION = {
+    "id": str(uuid4()),
+    "page_id": str(PAGE_ID),
+    "title": "Fire Anomaly",
+    "summary": "A thermal anomaly near Agroprom.",
+    "content": "# Fire Anomaly\n\n**Very hot.** Dangerous.",
+}
+
+
+def test_build_document_maps_fields_correctly():
+    doc = _build_document(SAMPLE_PAGE, SAMPLE_REVISION)
+    assert doc["page_id"] == str(PAGE_ID)
+    assert doc["slug"] == "fire-anomaly"
+    assert doc["type"] == "Anomaly"
+    assert doc["status"] == "Published"
+    assert doc["visibility"] == "Public"
+    assert doc["tags"] == ["fire", "thermal"]
+    assert doc["title"] == "Fire Anomaly"
+    assert doc["summary"] == "A thermal anomaly near Agroprom."
+
+
+def test_build_document_strips_markdown_from_content():
+    doc = _build_document(SAMPLE_PAGE, SAMPLE_REVISION)
+    assert "#" not in doc["content_text"]
+    assert "**" not in doc["content_text"]
+    assert "Fire Anomaly" in doc["content_text"]
+    assert "Very hot." in doc["content_text"]
+
+
+def test_build_document_has_aliases_field():
+    doc = _build_document(SAMPLE_PAGE, SAMPLE_REVISION)
+    assert "aliases" in doc
+    assert isinstance(doc["aliases"], list)
+
+
+async def test_upsert_page_indexes_using_published_revision():
+    os_client = AsyncMock()
+    enc_client = AsyncMock()
+    state = PageState(
+        page=SAMPLE_PAGE,
+        current_published_revision=SAMPLE_REVISION,
+        current_draft_revision=None,
+    )
+    enc_client.get_page_state.return_value = state
+
+    await upsert_page(PAGE_ID, enc_client, os_client, "test-index")
+
+    os_client.index.assert_called_once()
+    call_kwargs = os_client.index.call_args.kwargs
+    assert call_kwargs["index"] == "test-index"
+    assert call_kwargs["id"] == str(PAGE_ID)
+    assert call_kwargs["body"]["slug"] == "fire-anomaly"
+
+
+async def test_upsert_page_falls_back_to_draft_when_no_published_revision():
+    os_client = AsyncMock()
+    enc_client = AsyncMock()
+    draft_revision = {**SAMPLE_REVISION, "id": str(uuid4())}
+    state = PageState(
+        page=SAMPLE_PAGE,
+        current_published_revision=None,
+        current_draft_revision=draft_revision,
+    )
+    enc_client.get_page_state.return_value = state
+
+    await upsert_page(PAGE_ID, enc_client, os_client, "test-index")
+
+    os_client.index.assert_called_once()
+
+
+async def test_upsert_page_skips_when_no_revisions():
+    os_client = AsyncMock()
+    enc_client = AsyncMock()
+    state = PageState(
+        page=SAMPLE_PAGE,
+        current_published_revision=None,
+        current_draft_revision=None,
+    )
+    enc_client.get_page_state.return_value = state
+
+    await upsert_page(PAGE_ID, enc_client, os_client, "test-index")
+
+    os_client.index.assert_not_called()
+
+
+async def test_upsert_page_skips_when_page_not_found():
+    os_client = AsyncMock()
+    enc_client = AsyncMock()
+    enc_client.get_page_state.return_value = None
+
+    await upsert_page(PAGE_ID, enc_client, os_client, "test-index")
+
+    os_client.index.assert_not_called()
+
+
+async def test_delete_page_calls_os_delete_with_correct_args():
+    os_client = AsyncMock()
+
+    await delete_page(PAGE_ID, os_client, "test-index")
+
+    os_client.delete.assert_called_once_with(index="test-index", id=str(PAGE_ID))
+
+
+async def test_delete_page_does_not_raise_on_os_error():
+    os_client = AsyncMock()
+    os_client.delete.side_effect = Exception("not found")
+
+    await delete_page(PAGE_ID, os_client, "test-index")

--- a/services/search-indexer/tests/test_markdown.py
+++ b/services/search-indexer/tests/test_markdown.py
@@ -1,0 +1,50 @@
+from markdown import extract_plain_text
+
+
+def test_strips_atx_headings():
+    assert extract_plain_text("# Title\n\nBody.") == "Title Body."
+
+
+def test_strips_bold_asterisk():
+    assert extract_plain_text("This is **bold** text.") == "This is bold text."
+
+
+def test_strips_italic_underscore():
+    assert extract_plain_text("This is _italic_ text.") == "This is italic text."
+
+
+def test_strips_inline_links():
+    assert extract_plain_text("[Link text](https://example.com)") == "Link text"
+
+
+def test_strips_images():
+    assert extract_plain_text("![alt text](https://img.example.com/x.png)") == "alt text"
+
+
+def test_strips_fenced_code_blocks():
+    md = "Before\n```python\ncode = 1\n```\nAfter"
+    result = extract_plain_text(md)
+    assert "code = 1" not in result
+    assert "Before" in result
+    assert "After" in result
+
+
+def test_strips_inline_code():
+    result = extract_plain_text("Use the `x = 1` expression.")
+    assert "`" not in result
+    assert "x = 1" not in result
+
+
+def test_normalizes_whitespace_to_single_spaces():
+    result = extract_plain_text("Line one\n\nLine two")
+    assert "\n" not in result
+    assert "Line one" in result
+    assert "Line two" in result
+
+
+def test_empty_string_returns_empty():
+    assert extract_plain_text("") == ""
+
+
+def test_plain_text_passes_through():
+    assert extract_plain_text("Just plain text.") == "Just plain text."

--- a/services/search-service/routes/search.py
+++ b/services/search-service/routes/search.py
@@ -24,7 +24,7 @@ def _is_internal_request(request: Request, settings: Settings) -> bool:
         return False
     if role.lower() not in _INTERNAL_ROLES:
         return False
-    if settings.internal_token and token != settings.internal_token:
+    if not settings.internal_token.strip() or token != settings.internal_token:
         return False
     return True
 

--- a/services/search-service/tests/conftest.py
+++ b/services/search-service/tests/conftest.py
@@ -2,9 +2,10 @@ from unittest.mock import AsyncMock
 from fastapi import FastAPI
 from routes.search import router as search_router
 from routes.health import router as health_router
+from config import Settings, get_settings
 
 
-def build_search_app(opensearch_response: dict) -> tuple[FastAPI, AsyncMock]:
+def build_search_app(opensearch_response: dict, internal_token: str = "") -> tuple[FastAPI, AsyncMock]:
     fake_os = AsyncMock()
     fake_os.search.return_value = opensearch_response
     fake_os.ping.return_value = True
@@ -13,6 +14,11 @@ def build_search_app(opensearch_response: dict) -> tuple[FastAPI, AsyncMock]:
     app.state.opensearch = fake_os
     app.include_router(search_router)
     app.include_router(health_router)
+
+    if internal_token:
+        override_settings = Settings(internal_token=internal_token)
+        app.dependency_overrides[get_settings] = lambda: override_settings
+
     return app, fake_os
 
 

--- a/services/search-service/tests/test_search.py
+++ b/services/search-service/tests/test_search.py
@@ -41,16 +41,15 @@ async def test_search_applies_public_filter_when_no_auth_source_header():
     assert filter_terms.get("status") == "Published"
 
 
-# No X-Internal-Token is sent; internal_token defaults to "" so the token
-# check is skipped and the request is treated as internal based on headers alone.
 async def test_search_omits_visibility_filter_for_researcher():
-    app, fake_os = build_search_app(make_os_response([]))
+    app, fake_os = build_search_app(make_os_response([]), internal_token="test-token")
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         await client.get(
             "/search?q=fire",
             headers={
                 "X-Authenticated-Source": "api-gateway",
                 "X-Authenticated-User-Role": "Researcher",
+                "X-Internal-Token": "test-token",
             },
         )
 
@@ -148,16 +147,15 @@ async def test_suggest_applies_public_filter_for_anonymous():
     assert filter_terms.get("status") == "Published"
 
 
-# No X-Internal-Token is sent; internal_token defaults to "" so the token
-# check is skipped and the request is treated as internal based on headers alone.
 async def test_suggest_omits_public_filter_for_researcher():
-    app, fake_os = build_search_app(make_os_response([]))
+    app, fake_os = build_search_app(make_os_response([]), internal_token="test-token")
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         await client.get(
             "/search/suggest?q=fir",
             headers={
                 "X-Authenticated-Source": "api-gateway",
                 "X-Authenticated-User-Role": "Researcher",
+                "X-Internal-Token": "test-token",
             },
         )
 
@@ -332,15 +330,34 @@ async def test_search_returns_empty_snippet_when_no_highlights():
     assert response.json()["hits"][0]["snippet"] == ""
 
 
+async def test_internal_request_rejected_when_internal_token_is_whitespace():
+    app, fake_os = build_search_app(make_os_response([]), internal_token="   ")
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        await client.get(
+            "/search?q=fire",
+            headers={
+                "X-Authenticated-Source": "api-gateway",
+                "X-Authenticated-User-Role": "Researcher",
+                "X-Internal-Token": "   ",
+            },
+        )
+
+    filters = fake_os.search.call_args.kwargs["body"]["query"]["bool"]["filter"]
+    filter_keys = [list(f.get("term", {}).keys())[0] for f in filters if "term" in f]
+    assert "visibility" in filter_keys
+    assert "status" in filter_keys
+
+
 async def test_search_applies_visibility_filter_for_internal_request_when_provided():
     """Internal users can narrow by visibility when explicitly passed."""
-    app, fake_os = build_search_app(make_os_response([]))
+    app, fake_os = build_search_app(make_os_response([]), internal_token="test-token")
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         await client.get(
             "/search?q=fire&visibility=Private",
             headers={
                 "X-Authenticated-Source": "api-gateway",
                 "X-Authenticated-User-Role": "Researcher",
+                "X-Internal-Token": "test-token",
             },
         )
 
@@ -355,13 +372,14 @@ async def test_search_applies_visibility_filter_for_internal_request_when_provid
 
 async def test_search_applies_status_filter_for_internal_request_when_provided():
     """Internal users can narrow by status when explicitly passed."""
-    app, fake_os = build_search_app(make_os_response([]))
+    app, fake_os = build_search_app(make_os_response([]), internal_token="test-token")
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
         await client.get(
             "/search?q=fire&status=Draft",
             headers={
                 "X-Authenticated-Source": "api-gateway",
                 "X-Authenticated-User-Role": "Researcher",
+                "X-Internal-Token": "test-token",
             },
         )
 
@@ -376,23 +394,16 @@ async def test_search_applies_status_filter_for_internal_request_when_provided()
 
 async def test_search_treats_as_public_when_internal_token_mismatch():
     """Headers with wrong token must be treated as a public (not internal) request."""
-    from config import Settings, get_settings
-
-    app, fake_os = build_search_app(make_os_response([]))
-    patched_settings = Settings(internal_token="secret-abc")
-    app.dependency_overrides[get_settings] = lambda: patched_settings
-    try:
-        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
-            await client.get(
-                "/search?q=fire",
-                headers={
-                    "X-Authenticated-Source": "api-gateway",
-                    "X-Authenticated-User-Role": "Researcher",
-                    "X-Internal-Token": "WRONG_TOKEN",
-                },
-            )
-    finally:
-        app.dependency_overrides.clear()
+    app, fake_os = build_search_app(make_os_response([]), internal_token="secret-abc")
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        await client.get(
+            "/search?q=fire",
+            headers={
+                "X-Authenticated-Source": "api-gateway",
+                "X-Authenticated-User-Role": "Researcher",
+                "X-Internal-Token": "WRONG_TOKEN",
+            },
+        )
 
     call_args = fake_os.search.call_args
     filters = call_args.kwargs["body"]["query"]["bool"]["filter"]
@@ -404,25 +415,54 @@ async def test_search_treats_as_public_when_internal_token_mismatch():
     assert filter_terms.get("status") == "Published"
 
 
+async def test_internal_request_rejected_when_internal_token_not_configured():
+    # internal_token="" (default) — no request may claim internal status
+    app, fake_os = build_search_app(make_os_response([]))
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        await client.get(
+            "/search?q=fire",
+            headers={
+                "X-Authenticated-Source": "api-gateway",
+                "X-Authenticated-User-Role": "Researcher",
+            },
+        )
+
+    filters = fake_os.search.call_args.kwargs["body"]["query"]["bool"]["filter"]
+    filter_keys = [list(f.get("term", {}).keys())[0] for f in filters if "term" in f]
+    assert "visibility" in filter_keys
+    assert "status" in filter_keys
+
+
+async def test_internal_request_rejected_when_token_mismatch():
+    app, fake_os = build_search_app(make_os_response([]), internal_token="secret")
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        await client.get(
+            "/search?q=fire",
+            headers={
+                "X-Authenticated-Source": "api-gateway",
+                "X-Authenticated-User-Role": "Researcher",
+                "X-Internal-Token": "wrong-secret",
+            },
+        )
+
+    filters = fake_os.search.call_args.kwargs["body"]["query"]["bool"]["filter"]
+    filter_keys = [list(f.get("term", {}).keys())[0] for f in filters if "term" in f]
+    assert "visibility" in filter_keys
+    assert "status" in filter_keys
+
+
 async def test_search_treats_as_internal_when_token_matches():
     """Headers with correct token must be treated as an internal request."""
-    from config import Settings, get_settings
-
-    app, fake_os = build_search_app(make_os_response([]))
-    patched_settings = Settings(internal_token="secret-abc")
-    app.dependency_overrides[get_settings] = lambda: patched_settings
-    try:
-        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
-            await client.get(
-                "/search?q=fire",
-                headers={
-                    "X-Authenticated-Source": "api-gateway",
-                    "X-Authenticated-User-Role": "Researcher",
-                    "X-Internal-Token": "secret-abc",
-                },
-            )
-    finally:
-        app.dependency_overrides.clear()
+    app, fake_os = build_search_app(make_os_response([]), internal_token="secret-abc")
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as client:
+        await client.get(
+            "/search?q=fire",
+            headers={
+                "X-Authenticated-Source": "api-gateway",
+                "X-Authenticated-User-Role": "Researcher",
+                "X-Internal-Token": "secret-abc",
+            },
+        )
 
     call_args = fake_os.search.call_args
     filters = call_args.kwargs["body"]["query"]["bool"]["filter"]


### PR DESCRIPTION
Summary
                                                                                                                                                                                                                                                        
  - Add search-indexer-service — a standalone async Python worker that consumes domain events from RabbitMQ and maintains the OpenSearch index used by search-service
  - Add search-service — a FastAPI service exposing full-text and filtered search over encyclopedia pages via OpenSearch                                                                                                                                
  - Add encyclopedia-service — canonical source of truth for pages and revision history, now extended to publish domain events to RabbitMQ after all page mutations                                                                                     
  - Wire everything together in docker-compose.yml and add CI workflows for each service                                                                                                                                                                
                                                                                                                                                                                                                                                        
  Test plan                                                                                                                                                                                                                                             
                                                                                                                                                                                                                                                        
  - services/search-indexer/ — 29 unit tests: python -m pytest (no external deps needed)                                                                                                                                                                
  - services/encyclopedia/ — 22 unit/integration tests: python -m pytest (SQLite in-memory)
  - services/search-service/ — verify tests pass: python -m pytest                                                                                                                                                                                      
  - CI: push branch and confirm all three GitHub Actions workflows go green
  - Docker: docker compose up and verify search-indexer connects to RabbitMQ + OpenSearch, encyclopedia-service publishes events on page creation/publishing/status transitions, and search-service returns results   