### PR TITLE
fixed frontend issues

### DIFF
--- a/frontend/src/app/(app)/edit/[slug]/page.tsx
+++ b/frontend/src/app/(app)/edit/[slug]/page.tsx
@@ -39,7 +39,7 @@ function EditPageInner({ slug, isNew }: { slug: string; isNew: boolean }) {
   const { setBaseline, markDirty, reset } = useEditorStore();
   const qc = useQueryClient();
 
-  const { data, error, isFetching, isLoading, isError, refetch } = useQuery({
+  const { data, isFetching, isLoading, isError, error, refetch } = useQuery({
     queryKey: ["page", slug],
     queryFn: () => pagesApi.getBySlug(slug, token ?? undefined),
     enabled: !isNew,
@@ -198,8 +198,17 @@ function EditPageInner({ slug, isNew }: { slug: string; isNew: boolean }) {
     },
   });
 
-  const handleSave = () => { markDirty(); draftMutation.mutate(); };
+  const handleSave = () => { draftMutation.mutate(); };
   const handleNew  = () => createMutation.mutate();
+
+  const handleConflictReload = () => {
+    const ok = window.confirm(
+      "Reloading will discard your unsaved edits. Continue?",
+    );
+    if (!ok) return;
+    setConflict(false);
+    qc.invalidateQueries({ queryKey: ["page", slug] });
+  };
 
   const lineCount = md.split("\n").length;
   const charCount = md.length;
@@ -293,9 +302,9 @@ function EditPageInner({ slug, isNew }: { slug: string; isNew: boolean }) {
                 <button
                   className="btn btn--primary btn--sm"
                   onClick={() => submitMutation.mutate()}
-                  disabled={submitMutation.isPending}
+                  disabled={submitMutation.isPending || (data !== undefined && isFetching) || draftMutation.isPending}
                 >
-                  <Icon name="check" size={11} /> Submit for review
+                  <Icon name="check" size={11} /> {(data !== undefined && isFetching) ? "Syncing…" : "Submit for review"}
                 </button>
               )}
             </>
@@ -391,7 +400,7 @@ function EditPageInner({ slug, isNew }: { slug: string; isNew: boolean }) {
             Another user modified this record. Please{" "}
             <button
               className="btn btn--ghost btn--sm"
-              onClick={() => { setConflict(false); qc.invalidateQueries({ queryKey: ["page", slug] }); }}
+              onClick={handleConflictReload}
             >
               Reload latest
             </button>

--- a/frontend/src/app/(app)/wiki/[slug]/page.tsx
+++ b/frontend/src/app/(app)/wiki/[slug]/page.tsx
@@ -362,15 +362,18 @@ function RevisionsTab({ revisions }: { revisions: Revision[] }) {
   if (revisions.length === 0) {
     return <div className="muted" style={{ padding: "20px 0" }}>No revision history available.</div>;
   }
-  const latest  = revisions[0];
-  const prev    = revisions[1];
+  const sorted = [...revisions].sort(
+    (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
+  );
+  const latest  = sorted[0];
+  const prev    = sorted[1];
   const diffLines = generateDiff(prev?.content ?? "", latest?.content ?? "");
 
   return (
     <div className="article-grid" style={{ gridTemplateColumns: "1fr 320px" }}>
       <div>
         <div className="kicker" style={{ marginBottom: 10 }}>
-          Diff · r{revisions.length} ↔ r{revisions.length - 1}
+          Diff · r{sorted.length} ↔ r{sorted.length - 1}
         </div>
         <div className="diff" style={{ marginBottom: 24 }}>
           {diffLines.map((line, i) => (
@@ -384,10 +387,10 @@ function RevisionsTab({ revisions }: { revisions: Revision[] }) {
       <aside>
         <h6 className="kicker" style={{ marginBottom: 8 }}>Revision history</h6>
         <ul className="related-list">
-          {revisions.map((r, i) => (
+          {sorted.map((r, i) => (
             <li key={r.id} style={{ display: "block" }}>
               <div className="spread">
-                <b>r{revisions.length - i}</b>
+                <b>r{sorted.length - i}</b>
                 <span className="mono xsmall muted">{r.created_at.slice(0, 16)}</span>
               </div>
               <div className="xsmall" style={{ margin: "2px 0" }}>{r.summary || "No summary"}</div>

--- a/frontend/src/lib/api/client.ts
+++ b/frontend/src/lib/api/client.ts
@@ -5,6 +5,12 @@ const GATEWAY =
     ? process.env.GATEWAY_INTERNAL_URL ?? "http://localhost:8000"
     : process.env.NEXT_PUBLIC_GATEWAY_URL ?? "http://localhost:8000";
 
+let onUnauthorized: (() => void) | null = null;
+
+export function setUnauthorizedHandler(handler: () => void): void {
+  onUnauthorized = handler;
+}
+
 export async function request<T>(
   path: string,
   options: RequestInit & { token?: string } = {},
@@ -19,6 +25,9 @@ export async function request<T>(
   const res = await fetch(`${GATEWAY}${path}`, { ...init, headers });
 
   if (!res.ok) {
+    if (res.status === 401 && onUnauthorized && token) {
+      onUnauthorized();
+    }
     const body = await res.json().catch(() => ({}));
     const b = body as { detail?: string; error?: { message?: string } };
     const detail = b.detail ?? b.error?.message ?? "Unknown error";

--- a/frontend/src/lib/store/auth.ts
+++ b/frontend/src/lib/store/auth.ts
@@ -2,6 +2,7 @@
 import { create } from "zustand";
 import { jwtDecode } from "jwt-decode";
 import type { UserRole } from "@/lib/api/types";
+import { setUnauthorizedHandler } from "@/lib/api/client";
 
 interface JwtPayload {
   sub: string;
@@ -42,7 +43,7 @@ function parseToken(token: string): AuthUser | null {
   }
 }
 
-export const useAuthStore = create<AuthState>((set) => ({
+export const useAuthStore = create<AuthState>((set, get) => ({
   token: null,
   user: null,
   isAuthenticated: false,
@@ -62,6 +63,11 @@ export const useAuthStore = create<AuthState>((set) => ({
 
   hydrate: () => {
     if (typeof window === "undefined") return;
+
+    setUnauthorizedHandler(() => {
+      get().logout();
+    });
+
     const token = localStorage.getItem(TOKEN_KEY);
     if (!token) {
       set({ isHydrated: true });


### PR DESCRIPTION
## Summary

- **#61** `wiki/[slug]/page.tsx` — Sort revisions descending by `created_at` before indexing in `RevisionsTab`; previously assumed API returns newest-first which caused inverted diffs and mislabelled history entries
- **#62** `edit/[slug]/page.tsx` — Disable "Submit for review" while a save or post-save refetch is in flight (`draftMutation.isPending || (data !== undefined && isFetching)`) to prevent stale `page.version` 409 errors
- **#63** `edit/[slug]/page.tsx` — Remove spurious `markDirty()` from `handleSave`; it was already called in `onChange`/`insertImage` and incorrectly flagged unsaved edits after a failed save
- **#64** `edit/[slug]/page.tsx` — Gate "Reload latest" behind `window.confirm` so local edits are not silently discarded on conflict resolution
- **#65** `lib/api/client.ts` + `lib/store/auth.ts` — Intercept 401 responses via a module-level callback (`setUnauthorizedHandler`) wired in `hydrate()` to call `logout()`; gated on `&& token` so login failures with wrong credentials don't trigger logout

## Test Plan

- [ ] Open any wiki page → Revisions tab → confirm newest revision is at top and diff compares latest vs previous
- [ ] Edit a page → type changes → click Save draft → confirm "Saved." appears and no spurious dirty indicator after
- [ ] After Save draft, immediately click Submit for review → button shows "Syncing…" and is unclickable until cache refreshes
- [ ] Open same page in two tabs → save from one → click "Reload latest" in other → confirm dialog appears; Cancel preserves edits; OK reloads server data
- [ ] Let a JWT expire (edit `exp` in localStorage to a past timestamp) → perform any authenticated action → confirm redirect to `/login`