### PR TITLE
fixed issues 71-74

### DIFF
--- a/frontend/src/app/(app)/review/page.tsx
+++ b/frontend/src/app/(app)/review/page.tsx
@@ -1,9 +1,10 @@
 "use client";
 import { useRouter } from "next/navigation";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { AuthGuard } from "@/components/ui/AuthGuard";
 import { Icon } from "@/components/ui/Icon";
 import { PageTypeChip } from "@/components/ui/PageTypeChip";
+import { pagesApi } from "@/lib/api/pages";
 import { searchApi } from "@/lib/api/search";
 import { useAuthStore } from "@/lib/store/auth";
 
@@ -18,10 +19,27 @@ export default function ReviewPage() {
 function ReviewInner() {
   const router = useRouter();
   const { token } = useAuthStore();
+  const authToken = token!;
 
   const { data, isLoading, error } = useQuery({
     queryKey: ["search", "review"],
     queryFn: () => searchApi.query({ status: "Review" }, token ?? undefined),
+  });
+
+  const qc = useQueryClient();
+
+  const publishMutation = useMutation({
+    mutationFn: async (pageId: string) => {
+      const state = await pagesApi.getById(pageId, authToken);
+      const draftRevisionId = state.page.current_draft_revision_id;
+      if (!draftRevisionId) throw new Error("No draft revision available to publish.");
+      return pagesApi.publish(
+        pageId,
+        { revision_id: draftRevisionId, expected_page_version: state.page.version },
+        authToken,
+      );
+    },
+    onSuccess: () => qc.invalidateQueries({ queryKey: ["search", "review"] }),
   });
 
   const queue = data?.hits ?? [];
@@ -42,6 +60,13 @@ function ReviewInner() {
         <div className="callout callout--danger" style={{ marginBottom: 16 }}>
           <div className="callout__title">Error</div>
           Failed to load review records from search-service.
+        </div>
+      )}
+
+      {publishMutation.error && (
+        <div className="callout callout--danger" style={{ marginBottom: 16 }}>
+          <div className="callout__title">Publish failed</div>
+          {publishMutation.error instanceof Error ? publishMutation.error.message : "An unexpected error occurred."}
         </div>
       )}
 
@@ -67,10 +92,17 @@ function ReviewInner() {
           <div className="queue-row__diff">{record.visibility}</div>
           <div className="row" style={{ gap: 6, justifyContent: "flex-end" }}>
             <button
-              className="btn btn--primary btn--sm"
+              className="btn btn--ghost btn--sm"
               onClick={() => router.push(`/wiki/${record.slug}`)}
             >
-              <Icon name="check" size={11} /> Open
+              <Icon name="arrow" size={11} /> Open
+            </button>
+            <button
+              className="btn btn--primary btn--sm"
+              disabled={publishMutation.isPending}
+              onClick={() => publishMutation.mutate(record.page_id)}
+            >
+              <Icon name="check" size={11} /> Publish
             </button>
           </div>
         </div>

--- a/frontend/src/app/(app)/wiki/[slug]/page.tsx
+++ b/frontend/src/app/(app)/wiki/[slug]/page.tsx
@@ -456,10 +456,13 @@ function generateDiff(oldText: string, newText: string): DiffLine[] {
 function MediaTab({ pageId, token }: { pageId: string; token: string | null }) {
   const { data } = useQuery({
     queryKey: ["page-media", pageId],
-    queryFn: () => pagesApi.getById(pageId, token ?? undefined)
-      .then((state) => Promise.all(
-        state.page.media_asset_ids.map((assetId) => mediaApi.getAsset(assetId, token!)),
-      )),
+    queryFn: async () => {
+      if (!token) return [];
+      const state = await pagesApi.getById(pageId, token);
+      return Promise.all(
+        state.page.media_asset_ids.map((assetId) => mediaApi.getAsset(assetId, token)),
+      );
+    },
     enabled: !!token,
   });
 

--- a/frontend/src/lib/api/media.ts
+++ b/frontend/src/lib/api/media.ts
@@ -1,4 +1,5 @@
 import { request } from "./client";
+import { ApiError } from "./errors";
 import type { MediaAsset } from "./types";
 
 export const mediaApi = {
@@ -20,7 +21,7 @@ export const mediaApi = {
           (body as { detail?: string }).detail ??
           (body as { error?: { message?: string } }).error?.message ??
           "Upload failed";
-        throw new Error(detail);
+        throw new ApiError(res.status, detail, body);
       }
       return res.json() as Promise<MediaAsset>;
     }),


### PR DESCRIPTION
  Fix review queue UX and minor frontend code issues (#71, #72, #73, #74)
  
  Summary

  - #71 — Replace misleading checkmark icon on the review queue "Open" button with an arrow icon that correctly signals navigation
  - #72 — Add a "Publish" button directly in each review queue row, eliminating the queue → wiki page → dossier workflow for editors; publish errors are surfaced inline and concurrent publishes are safely blocked
  - #73 — Replace the hidden token! non-null assertion in MediaTab's query function with an explicit if (!token) return [] guard, making the type safety visible to TypeScript
  - #74 — Make mediaApi.upload throw ApiError (with HTTP status code) instead of a plain Error, consistent with every other API function

  Test plan

  - Navigate to /review as an Editor — "Open" button shows a right-arrow icon
  - Navigate to /review as an Editor — each row has a "Publish" button; clicking it publishes the record and removes it from the queue; a failed publish shows an inline error
  - Navigate to any wiki page → Media tab while signed out — no console errors, no token! crash
  - Trigger a failed upload in /media — error message still appears (ApiError extends Error, .message still works)
  - npx tsc --noEmit passes with no errors